### PR TITLE
fix: method parameters aren't escaped if they are keywords

### DIFF
--- a/src/Pharmacist.Core/Generation/RoslynGeneratorExtensions.cs
+++ b/src/Pharmacist.Core/Generation/RoslynGeneratorExtensions.cs
@@ -112,7 +112,7 @@ namespace Pharmacist.Core.Generation
             return SyntaxFactory.ParameterList(
                 SyntaxFactory.SeparatedList(
                     method.Parameters.Select(
-                        x => SyntaxFactory.Parameter(SyntaxFactory.Identifier(x.Name))
+                        x => SyntaxFactory.Parameter(SyntaxFactory.Identifier(x.Name.GetKeywordSafeName()))
                             .WithType(SyntaxFactory.IdentifierName(x.Type.GenerateFullGenericName())))));
         }
 


### PR DESCRIPTION
When names were keywords when passing method declarations the names should prefix with a '@' character.