### PR TITLE
Fix: don't produce FromEvent for events with reference parameters

### DIFF
--- a/src/Pharmacist.Core/Generation/Resolvers/EventNamespaceResolverBase.cs
+++ b/src/Pharmacist.Core/Generation/Resolvers/EventNamespaceResolverBase.cs
@@ -63,6 +63,24 @@ namespace Pharmacist.Core.Generation.Resolvers
             return GetEventGenerator().Generate(events);
         }
 
+        protected static bool IsValidParameters(IEvent eventDetails)
+        {
+            var invokeMethod = eventDetails.GetEventType().GetDelegateInvokeMethod();
+
+            // Events must have a valid return type.
+            if (invokeMethod == null || invokeMethod.ReturnType.FullName != "System.Void")
+            {
+                return false;
+            }
+
+            if (invokeMethod.Parameters.Any(x => x.IsRef))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         protected abstract IEventGenerator GetEventGenerator();
 
         protected abstract IEnumerable<ITypeDefinition> GetPublicTypesWithEvents(ICompilation compilation);

--- a/src/Pharmacist.Core/Generation/Resolvers/PublicEventNamespaceResolver.cs
+++ b/src/Pharmacist.Core/Generation/Resolvers/PublicEventNamespaceResolver.cs
@@ -19,7 +19,7 @@ namespace Pharmacist.Core.Generation.Resolvers
     {
         protected override IEnumerable<IEvent> GetValidEventDetails(IEnumerable<IEvent> eventDetails)
         {
-            return eventDetails.Where(x => x.Accessibility == Accessibility.Public && !x.IsStatic);
+            return eventDetails.Where(x => x.Accessibility == Accessibility.Public && !x.IsStatic && IsValidParameters(x));
         }
 
         protected override IEnumerable<ITypeDefinition> GetPublicTypesWithEvents(ICompilation compilation)

--- a/src/Pharmacist.Core/Generation/Resolvers/PublicStaticEventNamespaceResolver.cs
+++ b/src/Pharmacist.Core/Generation/Resolvers/PublicStaticEventNamespaceResolver.cs
@@ -26,7 +26,7 @@ namespace Pharmacist.Core.Generation.Resolvers
 
         protected override IEnumerable<IEvent> GetValidEventDetails(IEnumerable<IEvent> eventDetails)
         {
-            return eventDetails.Where(x => x.Accessibility == Accessibility.Public && x.IsStatic);
+            return eventDetails.Where(x => x.Accessibility == Accessibility.Public && x.IsStatic && IsValidParameters(x));
         }
     }
 }


### PR DESCRIPTION
We had some parameters with reference type in our platform producing code. Disallow those.

Some more comments on what different roslyn code to help those who come in after to understand what is getting produced.