### PR TITLE
Fix: make the platforms lower case to help with platform independence

### DIFF
--- a/src/Pharmacist.Core/ObservablesForEventGenerator.cs
+++ b/src/Pharmacist.Core/ObservablesForEventGenerator.cs
@@ -68,7 +68,7 @@ namespace Pharmacist.Core
                 var platformExtractor = _platformExtractors[platform];
                 await platformExtractor.Extract(defaultReferenceAssemblyLocation).ConfigureAwait(false);
 
-                using (var stream = new FileStream(Path.Combine(outputPath, $"{prefix}{platform}{suffix}"), FileMode.Create, FileAccess.Write))
+                using (var stream = new FileStream(Path.Combine(outputPath, $"{prefix}{platform.ToString().ToLowerInvariant()}{suffix}"), FileMode.Create, FileAccess.Write))
                 {
                     await WriteHeader(stream).ConfigureAwait(false);
                     await ExtractEventsFromAssemblies(stream, platformExtractor.Assemblies, platformExtractor.SearchDirectories).ConfigureAwait(false);


### PR DESCRIPTION
To make it easier to produce events on multiple platforms that have case sensitive file systems, just make the platform string lower case.