### PR TITLE
fix: Change so that if a event matches the standard event pattern

### DIFF
--- a/src/Pharmacist.Core/Generation/Generators/EventGeneratorBase.cs
+++ b/src/Pharmacist.Core/Generation/Generators/EventGeneratorBase.cs
@@ -68,9 +68,15 @@ namespace Pharmacist.Core.Generation.Generators
             ArgumentListSyntax methodParametersArgumentList;
             TypeSyntax eventArgsType;
 
-            // If we have any members call our observables with the parameters.
-            if (invokeMethod.Parameters.Count > 0)
+            // If we are using a standard approach of using 2 parameters only send the "Value", not the sender.
+            if (invokeMethod.Parameters.Count == 2 && invokeMethod.Parameters[0].Type.FullName == "System.Object")
             {
+                methodParametersArgumentList = invokeMethod.Parameters[1].GenerateArgumentList();
+                eventArgsType = SyntaxFactory.IdentifierName(invokeMethod.Parameters[1].Type.GenerateFullGenericName());
+            }
+            else if (invokeMethod.Parameters.Count > 0)
+            {
+                // If we have any members call our observables with the parameters.
                 // If we have only one member, produces arguments: (arg1);
                 // If we have greater than one member, produces arguments with value type: ((arg1, arg2))
                 methodParametersArgumentList = invokeMethod.Parameters.Count == 1 ? invokeMethod.Parameters[0].GenerateArgumentList() : invokeMethod.Parameters.GenerateTupleArgumentList();

--- a/src/Pharmacist.Core/Generation/Generators/EventGeneratorBase.cs
+++ b/src/Pharmacist.Core/Generation/Generators/EventGeneratorBase.cs
@@ -12,6 +12,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Pharmacist.Core.Generation.XmlSyntaxFactory;
+
 namespace Pharmacist.Core.Generation.Generators
 {
     /// <summary>
@@ -48,22 +51,22 @@ namespace Pharmacist.Core.Generation.Generators
             }
 
             SyntaxTokenList modifiers = eventDetails.IsStatic
-                ? SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword))
-                : SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
+                ? TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword))
+                : TokenList(Token(SyntaxKind.PublicKeyword));
 
             // Produces for static: public static global::System.IObservable<(argType1, argType2)> EventName => (contents of expression body)
             // Produces for instance: public global::System.IObservable<(argType1, argType2)> EventName => (contents of expression body)
-            return SyntaxFactory.PropertyDeclaration(observableEventArgType, prefix + eventDetails.Name)
+            return PropertyDeclaration(observableEventArgType, prefix + eventDetails.Name)
                 .WithModifiers(modifiers)
                 .WithExpressionBody(expressionBody)
-                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
                 .WithObsoleteAttribute(eventDetails)
-                .WithLeadingTrivia(XmlSyntaxFactory.GenerateSummarySeeAlsoComment("Gets an observable which signals when the {0} event triggers.", eventDetails.FullName));
+                .WithLeadingTrivia(GenerateSummarySeeAlsoComment("Gets an observable which signals when the {0} event triggers.", eventDetails.FullName));
         }
 
         private static (ArrowExpressionClauseSyntax, TypeSyntax) GenerateFromEventExpression(IEvent eventDetails, IMethod invokeMethod, string dataObjectName)
         {
-            var returnType = SyntaxFactory.IdentifierName(eventDetails.ReturnType.GenerateFullGenericName());
+            var returnType = IdentifierName(eventDetails.ReturnType.GenerateFullGenericName());
 
             ArgumentListSyntax methodParametersArgumentList;
             TypeSyntax eventArgsType;
@@ -72,7 +75,7 @@ namespace Pharmacist.Core.Generation.Generators
             if (invokeMethod.Parameters.Count == 2 && invokeMethod.Parameters[0].Type.FullName == "System.Object")
             {
                 methodParametersArgumentList = invokeMethod.Parameters[1].GenerateArgumentList();
-                eventArgsType = SyntaxFactory.IdentifierName(invokeMethod.Parameters[1].Type.GenerateFullGenericName());
+                eventArgsType = IdentifierName(invokeMethod.Parameters[1].Type.GenerateFullGenericName());
             }
             else if (invokeMethod.Parameters.Count > 0)
             {
@@ -80,53 +83,53 @@ namespace Pharmacist.Core.Generation.Generators
                 // If we have only one member, produces arguments: (arg1);
                 // If we have greater than one member, produces arguments with value type: ((arg1, arg2))
                 methodParametersArgumentList = invokeMethod.Parameters.Count == 1 ? invokeMethod.Parameters[0].GenerateArgumentList() : invokeMethod.Parameters.GenerateTupleArgumentList();
-                eventArgsType = invokeMethod.Parameters.Count == 1 ? SyntaxFactory.IdentifierName(invokeMethod.Parameters[0].Type.GenerateFullGenericName()) : invokeMethod.Parameters.Select(x => x.Type).GenerateTupleType();
+                eventArgsType = invokeMethod.Parameters.Count == 1 ? IdentifierName(invokeMethod.Parameters[0].Type.GenerateFullGenericName()) : invokeMethod.Parameters.Select(x => (x.Type, x.Name)).GenerateTupleType();
             }
             else
             {
                 // Produces argument: (global::System.Reactive.Unit.Default)
                 methodParametersArgumentList = RoslynHelpers.ReactiveUnitArgumentList;
-                eventArgsType = SyntaxFactory.IdentifierName(RoslynHelpers.ObservableUnitName);
+                eventArgsType = IdentifierName(RoslynHelpers.ObservableUnitName);
             }
 
             var eventName = eventDetails.Name;
 
             // Produces local function: void Handler(DataType1 eventParam1, DataType2 eventParam2) => eventHandler(eventParam1, eventParam2)
-            var localFunctionExpression = SyntaxFactory.LocalFunctionStatement(
-                                                SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
-                                                SyntaxFactory.Identifier("Handler"))
+            var localFunctionExpression = LocalFunctionStatement(
+                                                PredefinedType(Token(SyntaxKind.VoidKeyword)),
+                                                Identifier("Handler"))
                                             .WithParameterList(invokeMethod.GenerateMethodParameters())
                                             .WithExpressionBody(
-                                                SyntaxFactory.ArrowExpressionClause(
-                                                    SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName("eventHandler"))
+                                                ArrowExpressionClause(
+                                                    InvocationExpression(IdentifierName("eventHandler"))
                                                         .WithArgumentList(methodParametersArgumentList)))
-                                            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+                                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
             // Produces lambda expression: eventHandler => (local function above); return Handler;
-            var conversionLambdaExpression = SyntaxFactory.SimpleLambdaExpression(
-                SyntaxFactory.Parameter(SyntaxFactory.Identifier("eventHandler")),
-                SyntaxFactory.Block(localFunctionExpression, SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName("Handler"))));
+            var conversionLambdaExpression = SimpleLambdaExpression(
+                Parameter(Identifier("eventHandler")),
+                Block(localFunctionExpression, ReturnStatement(IdentifierName("Handler"))));
 
             // Produces type parameters: <EventArg1Type, EventArg2Type>
-            var fromEventTypeParameters = SyntaxFactory.TypeArgumentList(SyntaxFactory.SeparatedList<TypeSyntax>(new SyntaxNodeOrToken[] { returnType, SyntaxFactory.Token(SyntaxKind.CommaToken), eventArgsType }));
+            var fromEventTypeParameters = TypeArgumentList(SeparatedList<TypeSyntax>(new SyntaxNodeOrToken[] { returnType, Token(SyntaxKind.CommaToken), eventArgsType }));
 
             // Produces: => global::System.Reactive.Linq.Observable.FromEvent<TypeParameters>(h => (handler from above), x => x += DataObject.Event, x => x -= DataObject.Event);
-            var expression = SyntaxFactory.ArrowExpressionClause(
-                SyntaxFactory.InvocationExpression(
-                    SyntaxFactory.MemberAccessExpression(
+            var expression = ArrowExpressionClause(
+                InvocationExpression(
+                    MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.IdentifierName("global::System.Reactive.Linq.Observable"),
-                        SyntaxFactory.GenericName(SyntaxFactory.Identifier("FromEvent"))
+                        IdentifierName("global::System.Reactive.Linq.Observable"),
+                        GenericName(Identifier("FromEvent"))
                             .WithTypeArgumentList(fromEventTypeParameters)))
                         .WithArgumentList(
-                            SyntaxFactory.ArgumentList(
-                                SyntaxFactory.SeparatedList<ArgumentSyntax>(
+                            ArgumentList(
+                                SeparatedList<ArgumentSyntax>(
                                     new SyntaxNodeOrToken[]
                                     {
-                                            SyntaxFactory.Argument(conversionLambdaExpression),
-                                            SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                            Argument(conversionLambdaExpression),
+                                            Token(SyntaxKind.CommaToken),
                                             GenerateArgumentEventAccessor(SyntaxKind.AddAssignmentExpression, eventName, dataObjectName),
-                                            SyntaxFactory.Token(SyntaxKind.CommaToken),
+                                            Token(SyntaxKind.CommaToken),
                                             GenerateArgumentEventAccessor(SyntaxKind.SubtractAssignmentExpression, eventName, dataObjectName)
                                     }))));
 
@@ -136,16 +139,16 @@ namespace Pharmacist.Core.Generation.Generators
         private static ArgumentSyntax GenerateArgumentEventAccessor(SyntaxKind accessor, string eventName, string dataObjectName)
         {
             // This produces "x => dataObject.EventName += x" and also "x => dataObject.EventName -= x" depending on the accessor passed in.
-            return SyntaxFactory.Argument(
-                SyntaxFactory.SimpleLambdaExpression(
-                    SyntaxFactory.Parameter(SyntaxFactory.Identifier("x")),
-                    SyntaxFactory.AssignmentExpression(
+            return Argument(
+                SimpleLambdaExpression(
+                    Parameter(Identifier("x")),
+                    AssignmentExpression(
                         accessor,
-                        SyntaxFactory.MemberAccessExpression(
+                        MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
-                            SyntaxFactory.IdentifierName(dataObjectName),
-                            SyntaxFactory.IdentifierName(eventName)),
-                        SyntaxFactory.IdentifierName("x"))));
+                            IdentifierName(dataObjectName),
+                            IdentifierName(eventName)),
+                        IdentifierName("x"))));
         }
     }
 }

--- a/src/Pharmacist.Core/Generation/Generators/InstanceEventGenerator.cs
+++ b/src/Pharmacist.Core/Generation/Generators/InstanceEventGenerator.cs
@@ -12,6 +12,8 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
 namespace Pharmacist.Core.Generation.Generators
 {
     internal class InstanceEventGenerator : EventGeneratorBase
@@ -32,9 +34,8 @@ namespace Pharmacist.Core.Generation.Generators
 
                 if (members.Count > 0)
                 {
-                    yield return SyntaxFactory
-                        .NamespaceDeclaration(SyntaxFactory.IdentifierName(namespaceName))
-                        .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>(members));
+                    yield return NamespaceDeclaration(IdentifierName(namespaceName))
+                        .WithMembers(List<MemberDeclarationSyntax>(members));
                 }
             }
         }
@@ -43,23 +44,23 @@ namespace Pharmacist.Core.Generation.Generators
         {
             // Produces:
             // public static class EventExtensions
-            //   contents of members above
-            return SyntaxFactory.ClassDeclaration("EventExtensions")
-                .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
+            // contents of members above
+            return ClassDeclaration("EventExtensions")
+                .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
                 .WithLeadingTrivia(XmlSyntaxFactory.GenerateSummarySeeAlsoComment("A class that contains extension methods to wrap events for classes contained within the {0} namespace.", namespaceName))
-                .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>(declarations.Select(declaration =>
+                .WithMembers(List<MemberDeclarationSyntax>(declarations.Select(declaration =>
                     {
-                        var eventsClassName = SyntaxFactory.IdentifierName(declaration.Name + "Events");
-                        return SyntaxFactory.MethodDeclaration(eventsClassName, SyntaxFactory.Identifier("Events"))
-                            .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
-                            .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(
-                                SyntaxFactory.Parameter(SyntaxFactory.Identifier("item"))
-                                    .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.ThisKeyword)))
-                                    .WithType(SyntaxFactory.IdentifierName(declaration.GenerateFullGenericName())))))
-                            .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(
-                                SyntaxFactory.ObjectCreationExpression(eventsClassName)
-                                    .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(SyntaxFactory.IdentifierName("item")))))))
-                            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                        var eventsClassName = IdentifierName(declaration.Name + "Events");
+                        return MethodDeclaration(eventsClassName, Identifier("Events"))
+                            .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
+                            .WithParameterList(ParameterList(SingletonSeparatedList(
+                                Parameter(Identifier("item"))
+                                    .WithModifiers(TokenList(Token(SyntaxKind.ThisKeyword)))
+                                    .WithType(IdentifierName(declaration.GenerateFullGenericName())))))
+                            .WithExpressionBody(ArrowExpressionClause(
+                                ObjectCreationExpression(eventsClassName)
+                                    .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("item")))))))
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
                             .WithObsoleteAttribute(declaration)
                             .WithLeadingTrivia(XmlSyntaxFactory.GenerateSummarySeeAlsoComment("A wrapper class which wraps all the events contained within the {0} class.", declaration.GenerateFullGenericName()));
                     })));
@@ -67,29 +68,29 @@ namespace Pharmacist.Core.Generation.Generators
 
         private static ConstructorDeclarationSyntax GenerateEventWrapperClassConstructor(ITypeDefinition typeDefinition)
         {
-            return SyntaxFactory.ConstructorDeclaration(
-                    SyntaxFactory.Identifier(typeDefinition.Name + "Events"))
+            return ConstructorDeclaration(
+                    Identifier(typeDefinition.Name + "Events"))
                 .WithModifiers(
-                    SyntaxFactory.TokenList(
-                        SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
+                    TokenList(
+                        Token(SyntaxKind.PublicKeyword)))
                 .WithParameterList(
-                    SyntaxFactory.ParameterList(
-                        SyntaxFactory.SingletonSeparatedList(
-                            SyntaxFactory.Parameter(
-                                    SyntaxFactory.Identifier("data"))
+                    ParameterList(
+                        SingletonSeparatedList(
+                            Parameter(
+                                    Identifier("data"))
                                 .WithType(
-                                    SyntaxFactory.IdentifierName(typeDefinition.GenerateFullGenericName())))))
-                .WithBody(SyntaxFactory.Block(SyntaxFactory.SingletonList(
-                    SyntaxFactory.ExpressionStatement(
-                        SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, SyntaxFactory.IdentifierName(DataFieldName), SyntaxFactory.IdentifierName("data"))))))
+                                    IdentifierName(typeDefinition.GenerateFullGenericName())))))
+                .WithBody(Block(SingletonList(
+                    ExpressionStatement(
+                        AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, IdentifierName(DataFieldName), IdentifierName("data"))))))
                 .WithLeadingTrivia(XmlSyntaxFactory.GenerateSummarySeeAlsoComment("Initializes a new instance of the {0} class.", typeDefinition.GenerateFullGenericName(), ("data", "The class that is being wrapped.")));
         }
 
         private static FieldDeclarationSyntax GenerateEventWrapperField(ITypeDefinition typeDefinition)
         {
-            return SyntaxFactory.FieldDeclaration(SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName(typeDefinition.GenerateFullGenericName()))
-                .WithVariables(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(DataFieldName)))))
-                .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword), SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)));
+            return FieldDeclaration(VariableDeclaration(IdentifierName(typeDefinition.GenerateFullGenericName()))
+                .WithVariables(SingletonSeparatedList(VariableDeclarator(Identifier(DataFieldName)))))
+                .WithModifiers(TokenList(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.ReadOnlyKeyword)));
         }
 
         private static ClassDeclarationSyntax GenerateEventWrapperClass(ITypeDefinition typeDefinition, IEnumerable<IEvent> events)
@@ -97,9 +98,9 @@ namespace Pharmacist.Core.Generation.Generators
             var members = new List<MemberDeclarationSyntax> { GenerateEventWrapperField(typeDefinition), GenerateEventWrapperClassConstructor(typeDefinition) };
             members.AddRange(events.OrderBy(x => x.Name).Select(x => GenerateEventWrapperObservable(x, DataFieldName)).Where(x => x != null));
 
-            return SyntaxFactory.ClassDeclaration(typeDefinition.Name + "Events")
-                .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
-                .WithMembers(SyntaxFactory.List(members))
+            return ClassDeclaration(typeDefinition.Name + "Events")
+                .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                .WithMembers(List(members))
                 .WithObsoleteAttribute(typeDefinition)
                 .WithLeadingTrivia(XmlSyntaxFactory.GenerateSummarySeeAlsoComment("A class which wraps the events contained within the {0} class as observables.", typeDefinition.GenerateFullGenericName()));
         }

--- a/src/Pharmacist.Core/Generation/Generators/StaticEventGenerator.cs
+++ b/src/Pharmacist.Core/Generation/Generators/StaticEventGenerator.cs
@@ -12,6 +12,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static Pharmacist.Core.Generation.XmlSyntaxFactory;
+
 namespace Pharmacist.Core.Generation.Generators
 {
     internal class StaticEventGenerator : EventGeneratorBase
@@ -39,14 +42,13 @@ namespace Pharmacist.Core.Generation.Generators
 
                 if (eventWrapperMembers.Count > 0)
                 {
-                    var members = SyntaxFactory.ClassDeclaration("Events")
-                        .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
-                        .WithLeadingTrivia(XmlSyntaxFactory.GenerateSummarySeeAlsoComment("A class that contains extension methods to wrap events contained within static classes within the {0} namespace.", namespaceName))
-                        .WithMembers(SyntaxFactory.List<MemberDeclarationSyntax>(eventWrapperMembers));
+                    var members = ClassDeclaration("Events")
+                        .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
+                        .WithLeadingTrivia(GenerateSummarySeeAlsoComment("A class that contains extension methods to wrap events contained within static classes within the {0} namespace.", namespaceName))
+                        .WithMembers(List<MemberDeclarationSyntax>(eventWrapperMembers));
 
-                    yield return SyntaxFactory
-                        .NamespaceDeclaration(SyntaxFactory.IdentifierName(namespaceName))
-                        .WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(members));
+                    yield return NamespaceDeclaration(IdentifierName(namespaceName))
+                        .WithMembers(SingletonList<MemberDeclarationSyntax>(members));
                 }
             }
         }

--- a/src/Pharmacist.Core/Generation/RoslynGeneratorExtensions.cs
+++ b/src/Pharmacist.Core/Generation/RoslynGeneratorExtensions.cs
@@ -12,6 +12,8 @@ using ICSharpCode.Decompiler.TypeSystem;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
 namespace Pharmacist.Core.Generation
 {
     internal static class RoslynGeneratorExtensions
@@ -21,18 +23,23 @@ namespace Pharmacist.Core.Generation
         /// </summary>
         /// <param name="parameter">The parameter to generate the argument list for.</param>
         /// <returns>The argument list.</returns>
-        public static ArgumentListSyntax GenerateArgumentList(this IParameter parameter) => SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(SyntaxFactory.IdentifierName(parameter.Name.GetKeywordSafeName()))));
+        public static ArgumentListSyntax GenerateArgumentList(this IParameter parameter) => ArgumentList(SingletonSeparatedList(Argument(IdentifierName(parameter.Name.GetKeywordSafeName()))));
 
         /// <summary>
         /// Generates a argument list for a tuple parameter.
         /// </summary>
         /// <param name="parameters">The parameters to generate the argument list for.</param>
         /// <returns>The argument list.</returns>
-        public static ArgumentListSyntax GenerateTupleArgumentList(this IEnumerable<IParameter> parameters) => SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(SyntaxFactory.TupleExpression(SyntaxFactory.SeparatedList(parameters.Select(x => SyntaxFactory.Argument(SyntaxFactory.IdentifierName(x.Name.GetKeywordSafeName()))))))));
+        public static ArgumentListSyntax GenerateTupleArgumentList(this IEnumerable<IParameter> parameters) => ArgumentList(SingletonSeparatedList(Argument(TupleExpression(SeparatedList(parameters.Select(x => Argument(IdentifierName(x.Name.GetKeywordSafeName()))))))));
 
         public static TypeSyntax GenerateTupleType(this IEnumerable<IType> types)
         {
-            return SyntaxFactory.TupleType(SyntaxFactory.SeparatedList(types.Select(x => SyntaxFactory.TupleElement(SyntaxFactory.IdentifierName(x.GenerateFullGenericName())))));
+            return TupleType(SeparatedList(types.Select(x => TupleElement(IdentifierName(x.GenerateFullGenericName())))));
+        }
+
+        public static TypeSyntax GenerateTupleType(this IEnumerable<(IType type, string name)> types)
+        {
+            return TupleType(SeparatedList(types.Select(x => TupleElement(IdentifierName(x.type.GenerateFullGenericName()), Identifier(x.name)))));
         }
 
         public static TypeArgumentListSyntax GenerateObservableTypeArguments(this IMethod method)
@@ -42,15 +49,15 @@ namespace Pharmacist.Core.Generation
             // If we have no parameters, use the Unit type, if only one use the type directly, otherwise use a value tuple.
             if (method.Parameters.Count == 0)
             {
-                argumentList = SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList<TypeSyntax>(SyntaxFactory.IdentifierName(RoslynHelpers.ObservableUnitName)));
+                argumentList = TypeArgumentList(SingletonSeparatedList<TypeSyntax>(IdentifierName(RoslynHelpers.ObservableUnitName)));
             }
             else if (method.Parameters.Count == 1)
             {
-                argumentList = SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList<TypeSyntax>(SyntaxFactory.IdentifierName(method.Parameters[0].Type.GenerateFullGenericName())));
+                argumentList = TypeArgumentList(SingletonSeparatedList<TypeSyntax>(IdentifierName(method.Parameters[0].Type.GenerateFullGenericName())));
             }
             else
             {
-                argumentList = SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList<TypeSyntax>(SyntaxFactory.TupleType(SyntaxFactory.SeparatedList(method.Parameters.Select(x => SyntaxFactory.TupleElement(SyntaxFactory.IdentifierName(x.Type.GenerateFullGenericName())).WithIdentifier(SyntaxFactory.Identifier(x.Name)))))));
+                argumentList = TypeArgumentList(SingletonSeparatedList<TypeSyntax>(TupleType(SeparatedList(method.Parameters.Select(x => TupleElement(IdentifierName(x.Type.GenerateFullGenericName())).WithIdentifier(Identifier(x.Name)))))));
             }
 
             return argumentList;
@@ -58,12 +65,12 @@ namespace Pharmacist.Core.Generation
 
         public static TypeSyntax GenerateObservableType(this TypeArgumentListSyntax argumentList)
         {
-            return SyntaxFactory.QualifiedName(SyntaxFactory.IdentifierName("global::System"), SyntaxFactory.GenericName(SyntaxFactory.Identifier("IObservable")).WithTypeArgumentList(argumentList));
+            return QualifiedName(IdentifierName("global::System"), GenericName(Identifier("IObservable")).WithTypeArgumentList(argumentList));
         }
 
         public static TypeSyntax GenerateObservableType(this TypeSyntax argumentList)
         {
-            return SyntaxFactory.QualifiedName(SyntaxFactory.IdentifierName("global::System"), SyntaxFactory.GenericName(SyntaxFactory.Identifier("IObservable")).WithTypeArgumentList(SyntaxFactory.TypeArgumentList(SyntaxFactory.SingletonSeparatedList(argumentList))));
+            return QualifiedName(IdentifierName("global::System"), GenericName(Identifier("IObservable")).WithTypeArgumentList(TypeArgumentList(SingletonSeparatedList(argumentList))));
         }
 
         public static PropertyDeclarationSyntax WithObsoleteAttribute(this PropertyDeclarationSyntax syntax, IEntity eventDetails)
@@ -75,7 +82,7 @@ namespace Pharmacist.Core.Generation
                 return syntax;
             }
 
-            return syntax.WithAttributeLists(SyntaxFactory.SingletonList(attribute));
+            return syntax.WithAttributeLists(SingletonList(attribute));
         }
 
         public static ClassDeclarationSyntax WithObsoleteAttribute(this ClassDeclarationSyntax syntax, IEntity eventDetails)
@@ -87,7 +94,7 @@ namespace Pharmacist.Core.Generation
                 return syntax;
             }
 
-            return syntax.WithAttributeLists(SyntaxFactory.SingletonList(attribute));
+            return syntax.WithAttributeLists(SingletonList(attribute));
         }
 
         public static MethodDeclarationSyntax WithObsoleteAttribute(this MethodDeclarationSyntax syntax, IEntity eventDetails)
@@ -99,21 +106,21 @@ namespace Pharmacist.Core.Generation
                 return syntax;
             }
 
-            return syntax.WithAttributeLists(SyntaxFactory.SingletonList(attribute));
+            return syntax.WithAttributeLists(SingletonList(attribute));
         }
 
         public static ParameterListSyntax GenerateMethodParameters(this IMethod method)
         {
             if (method.Parameters.Count == 0)
             {
-                return SyntaxFactory.ParameterList();
+                return ParameterList();
             }
 
-            return SyntaxFactory.ParameterList(
-                SyntaxFactory.SeparatedList(
+            return ParameterList(
+                SeparatedList(
                     method.Parameters.Select(
-                        x => SyntaxFactory.Parameter(SyntaxFactory.Identifier(x.Name.GetKeywordSafeName()))
-                            .WithType(SyntaxFactory.IdentifierName(x.Type.GenerateFullGenericName())))));
+                        x => Parameter(Identifier(x.Name.GetKeywordSafeName()))
+                            .WithType(IdentifierName(x.Type.GenerateFullGenericName())))));
         }
 
         /// <summary>
@@ -131,13 +138,13 @@ namespace Pharmacist.Core.Generation
                 return null;
             }
 
-            var message = obsoleteAttribute.FixedArguments.FirstOrDefault().Value.ToString() ?? string.Empty;
+            var message = obsoleteAttribute.FixedArguments.FirstOrDefault().Value.ToString();
             var isError = bool.Parse(obsoleteAttribute.FixedArguments.ElementAtOrDefault(1).Value?.ToString() ?? bool.FalseString) ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression;
-            var attribute = SyntaxFactory.Attribute(
-                SyntaxFactory.IdentifierName("global::System.ObsoleteAttribute"),
-                SyntaxFactory.AttributeArgumentList(SyntaxFactory.SeparatedList(new[] { SyntaxFactory.AttributeArgument(SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(message))), SyntaxFactory.AttributeArgument(SyntaxFactory.LiteralExpression(isError)) })));
+            var attribute = Attribute(
+                IdentifierName("global::System.ObsoleteAttribute"),
+                AttributeArgumentList(SeparatedList(new[] { AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(message))), AttributeArgument(LiteralExpression(isError)) })));
 
-            return SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(attribute));
+            return AttributeList(SingletonSeparatedList(attribute));
         }
 
         private static string GetKeywordSafeName(this string name)

--- a/src/Pharmacist.Core/Generation/RoslynGeneratorExtensions.cs
+++ b/src/Pharmacist.Core/Generation/RoslynGeneratorExtensions.cs
@@ -32,14 +32,9 @@ namespace Pharmacist.Core.Generation
         /// <returns>The argument list.</returns>
         public static ArgumentListSyntax GenerateTupleArgumentList(this IEnumerable<IParameter> parameters) => ArgumentList(SingletonSeparatedList(Argument(TupleExpression(SeparatedList(parameters.Select(x => Argument(IdentifierName(x.Name.GetKeywordSafeName()))))))));
 
-        public static TypeSyntax GenerateTupleType(this IEnumerable<IType> types)
-        {
-            return TupleType(SeparatedList(types.Select(x => TupleElement(IdentifierName(x.GenerateFullGenericName())))));
-        }
-
         public static TypeSyntax GenerateTupleType(this IEnumerable<(IType type, string name)> types)
         {
-            return TupleType(SeparatedList(types.Select(x => TupleElement(IdentifierName(x.type.GenerateFullGenericName()), Identifier(x.name)))));
+            return TupleType(SeparatedList(types.Select(x => TupleElement(IdentifierName(x.type.GenerateFullGenericName()), Identifier(x.name.GetKeywordSafeName())))));
         }
 
         public static TypeArgumentListSyntax GenerateObservableTypeArguments(this IMethod method)

--- a/src/Pharmacist.Tests/IntegrationTests/Approved/Tizen.NET.API4.4.0.1.14152.approved.txt
+++ b/src/Pharmacist.Tests/IntegrationTests/Approved/Tizen.NET.API4.4.0.1.14152.approved.txt
@@ -194,9 +194,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Button.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -204,9 +204,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Button.Pressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -214,9 +214,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Button.Released"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -224,9 +224,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Button.Repeated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Repeated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Repeated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -251,9 +251,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Calendar.DateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.DateChangedEventArgs)> DateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.DateChangedEventArgs>, (object, global::ElmSharp.DateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.DateChangedEventArgs> DateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.DateChangedEventArgs>, global::ElmSharp.DateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.DateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.DateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -261,9 +261,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Calendar.DisplayedMonthChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.DisplayedMonthChangedEventArgs)> DisplayedMonthChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.DisplayedMonthChangedEventArgs>, (object, global::ElmSharp.DisplayedMonthChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.DisplayedMonthChangedEventArgs> DisplayedMonthChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.DisplayedMonthChangedEventArgs>, global::ElmSharp.DisplayedMonthChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.DisplayedMonthChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.DisplayedMonthChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -288,9 +288,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Check.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.CheckStateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.CheckStateChangedEventArgs>, (object, global::ElmSharp.CheckStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.CheckStateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.CheckStateChangedEventArgs>, global::ElmSharp.CheckStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.CheckStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.CheckStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -315,9 +315,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.ColorSelector.ColorChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.ColorChangedEventArgs)> ColorChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ColorChangedEventArgs>, (object, global::ElmSharp.ColorChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.ColorChangedEventArgs> ColorChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ColorChangedEventArgs>, global::ElmSharp.ColorChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.ColorChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.ColorChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -342,9 +342,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.ContextPopup.Dismissed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Dismissed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Dismissed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -369,9 +369,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.ContextPopupItem.Selected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -396,9 +396,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.DateTimeSelector.DateTimeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.DateChangedEventArgs)> DateTimeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.DateChangedEventArgs>, (object, global::ElmSharp.DateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.DateChangedEventArgs> DateTimeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.DateChangedEventArgs>, global::ElmSharp.DateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.DateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.DateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -423,9 +423,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EcoreTimelineAnimator.Finished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Finished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Finished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -450,9 +450,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EffectBase.EffectEnded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> EffectEnded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> EffectEnded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -477,9 +477,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Entry.Activated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Activated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Activated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -487,9 +487,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Entry.ChangedByUser"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ChangedByUser => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ChangedByUser => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -497,9 +497,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Entry.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -507,9 +507,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Entry.CursorChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> CursorChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> CursorChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -534,9 +534,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObject.BackButtonPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -544,9 +544,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObject.Deleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Deleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Deleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -554,9 +554,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObject.KeyDown"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.EvasKeyEventArgs)> KeyDown => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.EvasKeyEventArgs>, (object, global::ElmSharp.EvasKeyEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.EvasKeyEventArgs> KeyDown => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.EvasKeyEventArgs>, global::ElmSharp.EvasKeyEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.EvasKeyEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.EvasKeyEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -564,9 +564,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObject.KeyUp"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.EvasKeyEventArgs)> KeyUp => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.EvasKeyEventArgs>, (object, global::ElmSharp.EvasKeyEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.EvasKeyEventArgs> KeyUp => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.EvasKeyEventArgs>, global::ElmSharp.EvasKeyEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.EvasKeyEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.EvasKeyEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -574,9 +574,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObject.MoreButtonPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> MoreButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> MoreButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -584,9 +584,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObject.Moved"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Moved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Moved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -594,9 +594,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObject.RenderPost"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> RenderPost => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> RenderPost => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -604,9 +604,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObject.Resized"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Resized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Resized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -631,9 +631,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.EvasObjectEvent.On"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> On => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> On => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -658,9 +658,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.FlipSelector.Overflowed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Overflowed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Overflowed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -668,9 +668,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.FlipSelector.Selected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -678,9 +678,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.FlipSelector.Underflowed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Underflowed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Underflowed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -705,9 +705,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.FlipSelectorItem.Selected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -732,9 +732,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.Changed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -742,9 +742,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemActivated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemActivated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemActivated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -752,9 +752,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemDoubleClicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemDoubleClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemDoubleClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -762,9 +762,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemLongPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -772,9 +772,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -782,9 +782,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemRealized"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemRealized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemRealized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -792,9 +792,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemReleased"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemReleased => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemReleased => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -802,9 +802,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -812,9 +812,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemUnrealized"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemUnrealized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemUnrealized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -822,9 +822,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenGrid.ItemUnselected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenGridItemEventArgs)> ItemUnselected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, (object, global::ElmSharp.GenGridItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenGridItemEventArgs> ItemUnselected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenGridItemEventArgs>, global::ElmSharp.GenGridItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenGridItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -849,9 +849,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.Changed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -859,9 +859,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemActivated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemActivated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemActivated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -869,9 +869,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemDoubleClicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemDoubleClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemDoubleClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -879,9 +879,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemExpanded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemExpanded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemExpanded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -889,9 +889,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemLongPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -899,9 +899,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemMoved"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemMoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemMoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -909,9 +909,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemMovedAfter"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemMovedAfter => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemMovedAfter => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -919,9 +919,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemMovedBefore"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemMovedBefore => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemMovedBefore => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -929,9 +929,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -939,9 +939,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemRealized"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemRealized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemRealized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -949,9 +949,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemReleased"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemReleased => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemReleased => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -959,9 +959,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -969,9 +969,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemUnrealized"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemUnrealized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemUnrealized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -979,9 +979,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ItemUnselected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.GenListItemEventArgs)> ItemUnselected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, (object, global::ElmSharp.GenListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.GenListItemEventArgs> ItemUnselected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.GenListItemEventArgs>, global::ElmSharp.GenListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.GenListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -989,9 +989,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ScrollAnimationStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ScrollAnimationStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ScrollAnimationStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -999,9 +999,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.GenList.ScrollAnimationStopped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ScrollAnimationStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ScrollAnimationStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1026,9 +1026,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Hoversel.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1036,9 +1036,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Hoversel.Dismissed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Dismissed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Dismissed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1046,9 +1046,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Hoversel.Expanded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Expanded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Expanded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1056,9 +1056,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Hoversel.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.HoverselItemEventArgs)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.HoverselItemEventArgs>, (object, global::ElmSharp.HoverselItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.HoverselItemEventArgs> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.HoverselItemEventArgs>, global::ElmSharp.HoverselItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.HoverselItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.HoverselItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1083,9 +1083,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.HoverselItem.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1110,9 +1110,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Image.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1120,9 +1120,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Image.LoadingCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LoadingCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LoadingCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1130,9 +1130,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Image.LoadingFailed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LoadingFailed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LoadingFailed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1157,9 +1157,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Index.Changed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1184,9 +1184,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.IndexItem.Selected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1211,9 +1211,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.ItemObject.Deleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Deleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Deleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1238,9 +1238,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Label.SlideCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SlideCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SlideCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1265,9 +1265,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Layout.LanguageChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1275,9 +1275,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Layout.ThemeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ThemeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ThemeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1302,9 +1302,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.List.ItemActivated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.ListItemEventArgs)> ItemActivated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, (object, global::ElmSharp.ListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.ListItemEventArgs> ItemActivated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, global::ElmSharp.ListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1312,9 +1312,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.List.ItemDoubleClicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.ListItemEventArgs)> ItemDoubleClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, (object, global::ElmSharp.ListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.ListItemEventArgs> ItemDoubleClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, global::ElmSharp.ListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1322,9 +1322,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.List.ItemLongPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.ListItemEventArgs)> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, (object, global::ElmSharp.ListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.ListItemEventArgs> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, global::ElmSharp.ListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1332,9 +1332,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.List.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.ListItemEventArgs)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, (object, global::ElmSharp.ListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.ListItemEventArgs> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, global::ElmSharp.ListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1342,9 +1342,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.List.ItemUnselected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.ListItemEventArgs)> ItemUnselected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, (object, global::ElmSharp.ListItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.ListItemEventArgs> ItemUnselected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ListItemEventArgs>, global::ElmSharp.ListItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.ListItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1369,9 +1369,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1379,9 +1379,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.Contracted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Contracted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Contracted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1389,9 +1389,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.Expanded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Expanded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Expanded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1399,9 +1399,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.ExpandedStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ExpandedStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ExpandedStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1409,9 +1409,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.ItemAdded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.MultiButtonEntryItemEventArgs)> ItemAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, (object, global::ElmSharp.MultiButtonEntryItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.MultiButtonEntryItemEventArgs> ItemAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, global::ElmSharp.MultiButtonEntryItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1419,9 +1419,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.ItemClicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.MultiButtonEntryItemEventArgs)> ItemClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, (object, global::ElmSharp.MultiButtonEntryItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.MultiButtonEntryItemEventArgs> ItemClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, global::ElmSharp.MultiButtonEntryItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1429,9 +1429,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.ItemDeleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.MultiButtonEntryItemEventArgs)> ItemDeleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, (object, global::ElmSharp.MultiButtonEntryItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.MultiButtonEntryItemEventArgs> ItemDeleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, global::ElmSharp.MultiButtonEntryItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1439,9 +1439,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.ItemLongPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.MultiButtonEntryItemEventArgs)> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, (object, global::ElmSharp.MultiButtonEntryItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.MultiButtonEntryItemEventArgs> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, global::ElmSharp.MultiButtonEntryItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1449,9 +1449,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.MultiButtonEntry.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.MultiButtonEntryItemEventArgs)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, (object, global::ElmSharp.MultiButtonEntryItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.MultiButtonEntryItemEventArgs> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.MultiButtonEntryItemEventArgs>, global::ElmSharp.MultiButtonEntryItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.MultiButtonEntryItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1476,9 +1476,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Naviframe.AnimationFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1486,9 +1486,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Naviframe.Popped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.NaviframeEventArgs)> Popped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.NaviframeEventArgs>, (object, global::ElmSharp.NaviframeEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.NaviframeEventArgs> Popped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.NaviframeEventArgs>, global::ElmSharp.NaviframeEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.NaviframeEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.NaviframeEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1513,9 +1513,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.NaviItem.Popped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Popped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Popped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1540,9 +1540,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Panel.Toggled"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Toggled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Toggled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1567,9 +1567,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Panes.Pressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1577,9 +1577,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Panes.Unpressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Unpressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Unpressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1604,9 +1604,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Popup.Dismissed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Dismissed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Dismissed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1614,9 +1614,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Popup.OutsideClicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> OutsideClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> OutsideClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1624,9 +1624,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Popup.ShowAnimationFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ShowAnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ShowAnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1634,9 +1634,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Popup.TimedOut"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> TimedOut => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> TimedOut => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1661,9 +1661,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.ProgressBar.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1688,9 +1688,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Radio.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1715,9 +1715,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Scroller.DragStart"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DragStart => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DragStart => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1725,9 +1725,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Scroller.DragStop"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DragStop => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DragStop => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1735,9 +1735,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Scroller.PageScrolled"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> PageScrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> PageScrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1745,9 +1745,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Scroller.Scrolled"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Scrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Scrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1772,9 +1772,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Slider.DelayedValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DelayedValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DelayedValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1782,9 +1782,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Slider.DragStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DragStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DragStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1792,9 +1792,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Slider.DragStopped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DragStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DragStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1802,9 +1802,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Slider.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1829,9 +1829,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.SmartEvent.On"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> On => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> On => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1856,9 +1856,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Spinner.DelayedValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DelayedValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DelayedValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1866,9 +1866,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Spinner.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1893,9 +1893,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Toolbar.Selected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.ToolbarItemEventArgs)> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ToolbarItemEventArgs>, (object, global::ElmSharp.ToolbarItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.ToolbarItemEventArgs> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.ToolbarItemEventArgs>, global::ElmSharp.ToolbarItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.ToolbarItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.ToolbarItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1920,9 +1920,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.ToolbarItem.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1930,9 +1930,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.ToolbarItem.LongPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1940,9 +1940,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.ToolbarItem.Selected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1967,9 +1967,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Transit.Deleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Deleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Deleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1994,9 +1994,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Widget.Focused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2004,9 +2004,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Widget.Unfocused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2031,9 +2031,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Window.CloseRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> CloseRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> CloseRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2041,9 +2041,9 @@ namespace ElmSharp
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Window.RotationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> RotationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> RotationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2090,9 +2090,9 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Wearable.CircleSlider.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2117,9 +2117,9 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Wearable.MoreOption.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.Wearable.MoreOptionItemEventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.Wearable.MoreOptionItemEventArgs>, (object, global::ElmSharp.Wearable.MoreOptionItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.Wearable.MoreOptionItemEventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.Wearable.MoreOptionItemEventArgs>, global::ElmSharp.Wearable.MoreOptionItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.Wearable.MoreOptionItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.Wearable.MoreOptionItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2127,9 +2127,9 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Wearable.MoreOption.Closed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Closed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Closed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2137,9 +2137,9 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Wearable.MoreOption.Opened"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Opened => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Opened => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2147,9 +2147,9 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Wearable.MoreOption.Selected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.Wearable.MoreOptionItemEventArgs)> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.Wearable.MoreOptionItemEventArgs>, (object, global::ElmSharp.Wearable.MoreOptionItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.Wearable.MoreOptionItemEventArgs> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.Wearable.MoreOptionItemEventArgs>, global::ElmSharp.Wearable.MoreOptionItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.Wearable.MoreOptionItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.Wearable.MoreOptionItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2174,9 +2174,9 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Wearable.RotarySelector.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.Wearable.RotarySelectorItemEventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.Wearable.RotarySelectorItemEventArgs>, (object, global::ElmSharp.Wearable.RotarySelectorItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.Wearable.RotarySelectorItemEventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.Wearable.RotarySelectorItemEventArgs>, global::ElmSharp.Wearable.RotarySelectorItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.Wearable.RotarySelectorItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.Wearable.RotarySelectorItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2184,9 +2184,9 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Gets an observable which signals when the <see cref = "ElmSharp.Wearable.RotarySelector.Selected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::ElmSharp.Wearable.RotarySelectorItemEventArgs)> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.Wearable.RotarySelectorItemEventArgs>, (object, global::ElmSharp.Wearable.RotarySelectorItemEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::ElmSharp.Wearable.RotarySelectorItemEventArgs> Selected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::ElmSharp.Wearable.RotarySelectorItemEventArgs>, global::ElmSharp.Wearable.RotarySelectorItemEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::ElmSharp.Wearable.RotarySelectorItemEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::ElmSharp.Wearable.RotarySelectorItemEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2241,9 +2241,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreApplication.AppControlReceived"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.AppControlReceivedEventArgs)> AppControlReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.AppControlReceivedEventArgs>, (object, global::Tizen.Applications.AppControlReceivedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.AppControlReceivedEventArgs> AppControlReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.AppControlReceivedEventArgs>, global::Tizen.Applications.AppControlReceivedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.AppControlReceivedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.AppControlReceivedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2251,9 +2251,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreApplication.Created"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Created => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Created => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2261,9 +2261,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreApplication.DeviceOrientationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.DeviceOrientationEventArgs)> DeviceOrientationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.DeviceOrientationEventArgs>, (object, global::Tizen.Applications.DeviceOrientationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.DeviceOrientationEventArgs> DeviceOrientationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.DeviceOrientationEventArgs>, global::Tizen.Applications.DeviceOrientationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.DeviceOrientationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.DeviceOrientationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2271,9 +2271,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreApplication.LocaleChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.LocaleChangedEventArgs)> LocaleChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.LocaleChangedEventArgs>, (object, global::Tizen.Applications.LocaleChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.LocaleChangedEventArgs> LocaleChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.LocaleChangedEventArgs>, global::Tizen.Applications.LocaleChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.LocaleChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.LocaleChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2281,9 +2281,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreApplication.LowBattery"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.LowBatteryEventArgs)> LowBattery => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.LowBatteryEventArgs>, (object, global::Tizen.Applications.LowBatteryEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.LowBatteryEventArgs> LowBattery => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.LowBatteryEventArgs>, global::Tizen.Applications.LowBatteryEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.LowBatteryEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.LowBatteryEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2291,9 +2291,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreApplication.LowMemory"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.LowMemoryEventArgs)> LowMemory => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.LowMemoryEventArgs>, (object, global::Tizen.Applications.LowMemoryEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.LowMemoryEventArgs> LowMemory => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.LowMemoryEventArgs>, global::Tizen.Applications.LowMemoryEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.LowMemoryEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.LowMemoryEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2301,9 +2301,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreApplication.RegionFormatChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.RegionFormatChangedEventArgs)> RegionFormatChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.RegionFormatChangedEventArgs>, (object, global::Tizen.Applications.RegionFormatChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.RegionFormatChangedEventArgs> RegionFormatChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.RegionFormatChangedEventArgs>, global::Tizen.Applications.RegionFormatChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.RegionFormatChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.RegionFormatChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2311,9 +2311,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreApplication.Terminated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Terminated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Terminated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2338,9 +2338,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreUIApplication.Paused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Paused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Paused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2348,9 +2348,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.CoreUIApplication.Resumed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Resumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Resumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2375,9 +2375,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.Preference.EventContext.Changed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.PreferenceChangedEventArgs)> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PreferenceChangedEventArgs>, (object, global::Tizen.Applications.PreferenceChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.PreferenceChangedEventArgs> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PreferenceChangedEventArgs>, global::Tizen.Applications.PreferenceChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.PreferenceChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.PreferenceChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2402,9 +2402,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WatchApplication.AmbientChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.AmbientEventArgs)> AmbientChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.AmbientEventArgs>, (object, global::Tizen.Applications.AmbientEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.AmbientEventArgs> AmbientChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.AmbientEventArgs>, global::Tizen.Applications.AmbientEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.AmbientEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.AmbientEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2412,9 +2412,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WatchApplication.AmbientTick"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.TimeEventArgs)> AmbientTick => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.TimeEventArgs>, (object, global::Tizen.Applications.TimeEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.TimeEventArgs> AmbientTick => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.TimeEventArgs>, global::Tizen.Applications.TimeEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.TimeEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.TimeEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2422,9 +2422,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WatchApplication.Paused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Paused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Paused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2432,9 +2432,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WatchApplication.Resumed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Resumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Resumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2442,9 +2442,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WatchApplication.TimeTick"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.TimeEventArgs)> TimeTick => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.TimeEventArgs>, (object, global::Tizen.Applications.TimeEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.TimeEventArgs> TimeTick => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.TimeEventArgs>, global::Tizen.Applications.TimeEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.TimeEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.TimeEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2469,9 +2469,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WidgetControl.Created"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.WidgetLifecycleEventArgs)> Created => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.WidgetLifecycleEventArgs>, (object, global::Tizen.Applications.WidgetLifecycleEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.WidgetLifecycleEventArgs> Created => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.WidgetLifecycleEventArgs>, global::Tizen.Applications.WidgetLifecycleEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.WidgetLifecycleEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.WidgetLifecycleEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2479,9 +2479,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WidgetControl.Destroyed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.WidgetLifecycleEventArgs)> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.WidgetLifecycleEventArgs>, (object, global::Tizen.Applications.WidgetLifecycleEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.WidgetLifecycleEventArgs> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.WidgetLifecycleEventArgs>, global::Tizen.Applications.WidgetLifecycleEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.WidgetLifecycleEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.WidgetLifecycleEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2489,9 +2489,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WidgetControl.Paused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.WidgetLifecycleEventArgs)> Paused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.WidgetLifecycleEventArgs>, (object, global::Tizen.Applications.WidgetLifecycleEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.WidgetLifecycleEventArgs> Paused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.WidgetLifecycleEventArgs>, global::Tizen.Applications.WidgetLifecycleEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.WidgetLifecycleEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.WidgetLifecycleEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2499,9 +2499,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.WidgetControl.Resumed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.WidgetLifecycleEventArgs)> Resumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.WidgetLifecycleEventArgs>, (object, global::Tizen.Applications.WidgetLifecycleEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.WidgetLifecycleEventArgs> Resumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.WidgetLifecycleEventArgs>, global::Tizen.Applications.WidgetLifecycleEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.WidgetLifecycleEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.WidgetLifecycleEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2540,9 +2540,9 @@ namespace Tizen.Applications.AttachPanel
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.AttachPanel.AttachPanel.EventChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.AttachPanel.StateEventArgs)> EventChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.AttachPanel.StateEventArgs>, (object, global::Tizen.Applications.AttachPanel.StateEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.AttachPanel.StateEventArgs> EventChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.AttachPanel.StateEventArgs>, global::Tizen.Applications.AttachPanel.StateEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.AttachPanel.StateEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.AttachPanel.StateEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2550,9 +2550,9 @@ namespace Tizen.Applications.AttachPanel
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.AttachPanel.AttachPanel.ResultCallback"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.AttachPanel.ResultEventArgs)> ResultCallback => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.AttachPanel.ResultEventArgs>, (object, global::Tizen.Applications.AttachPanel.ResultEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.AttachPanel.ResultEventArgs> ResultCallback => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.AttachPanel.ResultEventArgs>, global::Tizen.Applications.AttachPanel.ResultEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.AttachPanel.ResultEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.AttachPanel.ResultEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2595,9 +2595,9 @@ namespace Tizen.Applications.Messages
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.Messages.MessagePort.MessageReceived"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.Messages.MessageReceivedEventArgs)> MessageReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.Messages.MessageReceivedEventArgs>, (object, global::Tizen.Applications.Messages.MessageReceivedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.Messages.MessageReceivedEventArgs> MessageReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.Messages.MessageReceivedEventArgs>, global::Tizen.Applications.Messages.MessageReceivedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.Messages.MessageReceivedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.Messages.MessageReceivedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2622,9 +2622,9 @@ namespace Tizen.Applications.Messages
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.Messages.RemotePort.RemotePortStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Applications.Messages.RemotePortStateChangedEventArgs)> RemotePortStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.Messages.RemotePortStateChangedEventArgs>, (object, global::Tizen.Applications.Messages.RemotePortStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Applications.Messages.RemotePortStateChangedEventArgs> RemotePortStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.Messages.RemotePortStateChangedEventArgs>, global::Tizen.Applications.Messages.RemotePortStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.Messages.RemotePortStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.Messages.RemotePortStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2663,9 +2663,9 @@ namespace Tizen.Content.Download
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Content.Download.Request.ProgressChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Content.Download.ProgressChangedEventArgs)> ProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Content.Download.ProgressChangedEventArgs>, (object, global::Tizen.Content.Download.ProgressChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Content.Download.ProgressChangedEventArgs> ProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Content.Download.ProgressChangedEventArgs>, global::Tizen.Content.Download.ProgressChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Content.Download.ProgressChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Content.Download.ProgressChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2673,9 +2673,9 @@ namespace Tizen.Content.Download
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Content.Download.Request.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Content.Download.StateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Content.Download.StateChangedEventArgs>, (object, global::Tizen.Content.Download.StateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Content.Download.StateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Content.Download.StateChangedEventArgs>, global::Tizen.Content.Download.StateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Content.Download.StateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Content.Download.StateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2718,9 +2718,9 @@ namespace Tizen.Location
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.GpsSatellite.SatelliteStatusUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.SatelliteStatusChangedEventArgs)> SatelliteStatusUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.SatelliteStatusChangedEventArgs>, (object, global::Tizen.Location.SatelliteStatusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.SatelliteStatusChangedEventArgs> SatelliteStatusUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.SatelliteStatusChangedEventArgs>, global::Tizen.Location.SatelliteStatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.SatelliteStatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.SatelliteStatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2745,9 +2745,9 @@ namespace Tizen.Location
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.Locator.DistanceBasedLocationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.LocationChangedEventArgs)> DistanceBasedLocationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.LocationChangedEventArgs>, (object, global::Tizen.Location.LocationChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.LocationChangedEventArgs> DistanceBasedLocationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.LocationChangedEventArgs>, global::Tizen.Location.LocationChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.LocationChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.LocationChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2755,9 +2755,9 @@ namespace Tizen.Location
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.Locator.LocationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.LocationChangedEventArgs)> LocationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.LocationChangedEventArgs>, (object, global::Tizen.Location.LocationChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.LocationChangedEventArgs> LocationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.LocationChangedEventArgs>, global::Tizen.Location.LocationChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.LocationChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.LocationChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2765,9 +2765,9 @@ namespace Tizen.Location
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.Locator.ServiceStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.ServiceStateChangedEventArgs)> ServiceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.ServiceStateChangedEventArgs>, (object, global::Tizen.Location.ServiceStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.ServiceStateChangedEventArgs> ServiceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.ServiceStateChangedEventArgs>, global::Tizen.Location.ServiceStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.ServiceStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.ServiceStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2775,9 +2775,9 @@ namespace Tizen.Location
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.Locator.SettingChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.SettingChangedEventArgs)> SettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.SettingChangedEventArgs>, (object, global::Tizen.Location.SettingChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.SettingChangedEventArgs> SettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.SettingChangedEventArgs>, global::Tizen.Location.SettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.SettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.SettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2785,9 +2785,9 @@ namespace Tizen.Location
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.Locator.ZoneChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.ZoneChangedEventArgs)> ZoneChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.ZoneChangedEventArgs>, (object, global::Tizen.Location.ZoneChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.ZoneChangedEventArgs> ZoneChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.ZoneChangedEventArgs>, global::Tizen.Location.ZoneChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.ZoneChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.ZoneChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2826,9 +2826,9 @@ namespace Tizen.Location.Geofence
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.Geofence.GeofenceManager.GeofenceEventChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.Geofence.GeofenceResponseEventArgs)> GeofenceEventChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.Geofence.GeofenceResponseEventArgs>, (object, global::Tizen.Location.Geofence.GeofenceResponseEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.Geofence.GeofenceResponseEventArgs> GeofenceEventChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.Geofence.GeofenceResponseEventArgs>, global::Tizen.Location.Geofence.GeofenceResponseEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.Geofence.GeofenceResponseEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.Geofence.GeofenceResponseEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2836,9 +2836,9 @@ namespace Tizen.Location.Geofence
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.Geofence.GeofenceManager.ProximityChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.Geofence.ProximityStateEventArgs)> ProximityChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.Geofence.ProximityStateEventArgs>, (object, global::Tizen.Location.Geofence.ProximityStateEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.Geofence.ProximityStateEventArgs> ProximityChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.Geofence.ProximityStateEventArgs>, global::Tizen.Location.Geofence.ProximityStateEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.Geofence.ProximityStateEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.Geofence.ProximityStateEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2846,9 +2846,9 @@ namespace Tizen.Location.Geofence
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Location.Geofence.GeofenceManager.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Location.Geofence.GeofenceStateEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.Geofence.GeofenceStateEventArgs>, (object, global::Tizen.Location.Geofence.GeofenceStateEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Location.Geofence.GeofenceStateEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Location.Geofence.GeofenceStateEventArgs>, global::Tizen.Location.Geofence.GeofenceStateEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Location.Geofence.GeofenceStateEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Location.Geofence.GeofenceStateEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2899,9 +2899,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.MapView.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Maps.MapGestureEventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, (object, global::Tizen.Maps.MapGestureEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Maps.MapGestureEventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, global::Tizen.Maps.MapGestureEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2909,9 +2909,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.MapView.DoubleClicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Maps.MapGestureEventArgs)> DoubleClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, (object, global::Tizen.Maps.MapGestureEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Maps.MapGestureEventArgs> DoubleClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, global::Tizen.Maps.MapGestureEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2919,9 +2919,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.MapView.LongPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Maps.MapGestureEventArgs)> LongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, (object, global::Tizen.Maps.MapGestureEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Maps.MapGestureEventArgs> LongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, global::Tizen.Maps.MapGestureEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2929,9 +2929,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.MapView.Scrolled"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Maps.MapGestureEventArgs)> Scrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, (object, global::Tizen.Maps.MapGestureEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Maps.MapGestureEventArgs> Scrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, global::Tizen.Maps.MapGestureEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2939,9 +2939,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.MapView.TwoFingerClicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Maps.MapGestureEventArgs)> TwoFingerClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, (object, global::Tizen.Maps.MapGestureEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Maps.MapGestureEventArgs> TwoFingerClicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, global::Tizen.Maps.MapGestureEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2949,9 +2949,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.MapView.TwoFingerRotated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Maps.MapGestureEventArgs)> TwoFingerRotated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, (object, global::Tizen.Maps.MapGestureEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Maps.MapGestureEventArgs> TwoFingerRotated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, global::Tizen.Maps.MapGestureEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2959,9 +2959,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.MapView.TwoFingerZoomed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Maps.MapGestureEventArgs)> TwoFingerZoomed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, (object, global::Tizen.Maps.MapGestureEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Maps.MapGestureEventArgs> TwoFingerZoomed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Maps.MapGestureEventArgs>, global::Tizen.Maps.MapGestureEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Maps.MapGestureEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2969,9 +2969,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.MapView.ViewReady"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ViewReady => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ViewReady => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2996,9 +2996,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.Marker.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3023,9 +3023,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.Polygon.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3050,9 +3050,9 @@ namespace Tizen.Maps
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Maps.Polyline.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3131,9 +3131,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AsyncAudioCapture.DataAvailable"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.AudioDataAvailableEventArgs)> DataAvailable => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioDataAvailableEventArgs>, (object, global::Tizen.Multimedia.AudioDataAvailableEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.AudioDataAvailableEventArgs> DataAvailable => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioDataAvailableEventArgs>, global::Tizen.Multimedia.AudioDataAvailableEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.AudioDataAvailableEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.AudioDataAvailableEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3158,9 +3158,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AudioCaptureBase.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.AudioIOStateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioIOStateChangedEventArgs>, (object, global::Tizen.Multimedia.AudioIOStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.AudioIOStateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioIOStateChangedEventArgs>, global::Tizen.Multimedia.AudioIOStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.AudioIOStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.AudioIOStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3185,9 +3185,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AudioPlayback.BufferAvailable"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.AudioPlaybackBufferAvailableEventArgs)> BufferAvailable => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioPlaybackBufferAvailableEventArgs>, (object, global::Tizen.Multimedia.AudioPlaybackBufferAvailableEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.AudioPlaybackBufferAvailableEventArgs> BufferAvailable => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioPlaybackBufferAvailableEventArgs>, global::Tizen.Multimedia.AudioPlaybackBufferAvailableEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.AudioPlaybackBufferAvailableEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.AudioPlaybackBufferAvailableEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3195,9 +3195,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AudioPlayback.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.AudioIOStateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioIOStateChangedEventArgs>, (object, global::Tizen.Multimedia.AudioIOStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.AudioIOStateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioIOStateChangedEventArgs>, global::Tizen.Multimedia.AudioIOStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.AudioIOStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.AudioIOStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3222,9 +3222,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AudioStreamPolicy.FocusStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.AudioStreamPolicyFocusStateChangedEventArgs)> FocusStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioStreamPolicyFocusStateChangedEventArgs>, (object, global::Tizen.Multimedia.AudioStreamPolicyFocusStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.AudioStreamPolicyFocusStateChangedEventArgs> FocusStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioStreamPolicyFocusStateChangedEventArgs>, global::Tizen.Multimedia.AudioStreamPolicyFocusStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.AudioStreamPolicyFocusStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.AudioStreamPolicyFocusStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3249,9 +3249,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AudioVolume.Changed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.VolumeChangedEventArgs)> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.VolumeChangedEventArgs>, (object, global::Tizen.Multimedia.VolumeChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.VolumeChangedEventArgs> Changed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.VolumeChangedEventArgs>, global::Tizen.Multimedia.VolumeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.VolumeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.VolumeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3276,9 +3276,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.CaptureCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> CaptureCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> CaptureCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3286,9 +3286,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.Capturing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.CameraCapturingEventArgs)> Capturing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraCapturingEventArgs>, (object, global::Tizen.Multimedia.CameraCapturingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.CameraCapturingEventArgs> Capturing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraCapturingEventArgs>, global::Tizen.Multimedia.CameraCapturingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.CameraCapturingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.CameraCapturingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3296,9 +3296,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.ErrorOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.CameraErrorOccurredEventArgs)> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraErrorOccurredEventArgs>, (object, global::Tizen.Multimedia.CameraErrorOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.CameraErrorOccurredEventArgs> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraErrorOccurredEventArgs>, global::Tizen.Multimedia.CameraErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.CameraErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.CameraErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3306,9 +3306,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.FaceDetected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.FaceDetectedEventArgs)> FaceDetected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.FaceDetectedEventArgs>, (object, global::Tizen.Multimedia.FaceDetectedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.FaceDetectedEventArgs> FaceDetected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.FaceDetectedEventArgs>, global::Tizen.Multimedia.FaceDetectedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.FaceDetectedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.FaceDetectedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3316,9 +3316,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.FocusStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.CameraFocusStateChangedEventArgs)> FocusStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraFocusStateChangedEventArgs>, (object, global::Tizen.Multimedia.CameraFocusStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.CameraFocusStateChangedEventArgs> FocusStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraFocusStateChangedEventArgs>, global::Tizen.Multimedia.CameraFocusStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.CameraFocusStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.CameraFocusStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3326,9 +3326,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.HdrCaptureProgress"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.HdrCaptureProgressEventArgs)> HdrCaptureProgress => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.HdrCaptureProgressEventArgs>, (object, global::Tizen.Multimedia.HdrCaptureProgressEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.HdrCaptureProgressEventArgs> HdrCaptureProgress => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.HdrCaptureProgressEventArgs>, global::Tizen.Multimedia.HdrCaptureProgressEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.HdrCaptureProgressEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.HdrCaptureProgressEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3336,9 +3336,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.Interrupted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.CameraInterruptedEventArgs)> Interrupted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraInterruptedEventArgs>, (object, global::Tizen.Multimedia.CameraInterruptedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.CameraInterruptedEventArgs> Interrupted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraInterruptedEventArgs>, global::Tizen.Multimedia.CameraInterruptedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.CameraInterruptedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.CameraInterruptedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3346,9 +3346,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.InterruptStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.CameraInterruptStartedEventArgs)> InterruptStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraInterruptStartedEventArgs>, (object, global::Tizen.Multimedia.CameraInterruptStartedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.CameraInterruptStartedEventArgs> InterruptStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraInterruptStartedEventArgs>, global::Tizen.Multimedia.CameraInterruptStartedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.CameraInterruptStartedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.CameraInterruptStartedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3356,9 +3356,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.MediaPacketPreview"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.MediaPacketPreviewEventArgs)> MediaPacketPreview => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaPacketPreviewEventArgs>, (object, global::Tizen.Multimedia.MediaPacketPreviewEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.MediaPacketPreviewEventArgs> MediaPacketPreview => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaPacketPreviewEventArgs>, global::Tizen.Multimedia.MediaPacketPreviewEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.MediaPacketPreviewEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.MediaPacketPreviewEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3366,9 +3366,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.Preview"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.PreviewEventArgs)> Preview => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.PreviewEventArgs>, (object, global::Tizen.Multimedia.PreviewEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.PreviewEventArgs> Preview => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.PreviewEventArgs>, global::Tizen.Multimedia.PreviewEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.PreviewEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.PreviewEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3376,9 +3376,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.CameraStateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraStateChangedEventArgs>, (object, global::Tizen.Multimedia.CameraStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.CameraStateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraStateChangedEventArgs>, global::Tizen.Multimedia.CameraStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.CameraStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.CameraStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3403,9 +3403,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.MediaStreamConfiguration.BufferStatusChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.MediaStreamBufferStatusChangedEventArgs)> BufferStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaStreamBufferStatusChangedEventArgs>, (object, global::Tizen.Multimedia.MediaStreamBufferStatusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.MediaStreamBufferStatusChangedEventArgs> BufferStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaStreamBufferStatusChangedEventArgs>, global::Tizen.Multimedia.MediaStreamBufferStatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.MediaStreamBufferStatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.MediaStreamBufferStatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3413,9 +3413,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.MediaStreamConfiguration.SeekingOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.MediaStreamSeekingOccurredEventArgs)> SeekingOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaStreamSeekingOccurredEventArgs>, (object, global::Tizen.Multimedia.MediaStreamSeekingOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.MediaStreamSeekingOccurredEventArgs> SeekingOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaStreamSeekingOccurredEventArgs>, global::Tizen.Multimedia.MediaStreamSeekingOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.MediaStreamSeekingOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.MediaStreamSeekingOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3440,9 +3440,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Player.BufferingProgressChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.BufferingProgressChangedEventArgs)> BufferingProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.BufferingProgressChangedEventArgs>, (object, global::Tizen.Multimedia.BufferingProgressChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.BufferingProgressChangedEventArgs> BufferingProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.BufferingProgressChangedEventArgs>, global::Tizen.Multimedia.BufferingProgressChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.BufferingProgressChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.BufferingProgressChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3450,9 +3450,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Player.ErrorOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.PlayerErrorOccurredEventArgs)> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.PlayerErrorOccurredEventArgs>, (object, global::Tizen.Multimedia.PlayerErrorOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.PlayerErrorOccurredEventArgs> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.PlayerErrorOccurredEventArgs>, global::Tizen.Multimedia.PlayerErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.PlayerErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.PlayerErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3460,9 +3460,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Player.PlaybackCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> PlaybackCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> PlaybackCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3470,9 +3470,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Player.PlaybackInterrupted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.PlaybackInterruptedEventArgs)> PlaybackInterrupted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.PlaybackInterruptedEventArgs>, (object, global::Tizen.Multimedia.PlaybackInterruptedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.PlaybackInterruptedEventArgs> PlaybackInterrupted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.PlaybackInterruptedEventArgs>, global::Tizen.Multimedia.PlaybackInterruptedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.PlaybackInterruptedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.PlaybackInterruptedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3480,9 +3480,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Player.SubtitleUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.SubtitleUpdatedEventArgs)> SubtitleUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.SubtitleUpdatedEventArgs>, (object, global::Tizen.Multimedia.SubtitleUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.SubtitleUpdatedEventArgs> SubtitleUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.SubtitleUpdatedEventArgs>, global::Tizen.Multimedia.SubtitleUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.SubtitleUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.SubtitleUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3490,9 +3490,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Player.VideoFrameDecoded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.VideoFrameDecodedEventArgs)> VideoFrameDecoded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.VideoFrameDecodedEventArgs>, (object, global::Tizen.Multimedia.VideoFrameDecodedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.VideoFrameDecodedEventArgs> VideoFrameDecoded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.VideoFrameDecodedEventArgs>, global::Tizen.Multimedia.VideoFrameDecodedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.VideoFrameDecodedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.VideoFrameDecodedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3500,9 +3500,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Player.VideoStreamChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.VideoStreamChangedEventArgs)> VideoStreamChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.VideoStreamChangedEventArgs>, (object, global::Tizen.Multimedia.VideoStreamChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.VideoStreamChangedEventArgs> VideoStreamChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.VideoStreamChangedEventArgs>, global::Tizen.Multimedia.VideoStreamChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.VideoStreamChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.VideoStreamChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3527,9 +3527,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Radio.Interrupted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RadioInterruptedEventArgs)> Interrupted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RadioInterruptedEventArgs>, (object, global::Tizen.Multimedia.RadioInterruptedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RadioInterruptedEventArgs> Interrupted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RadioInterruptedEventArgs>, global::Tizen.Multimedia.RadioInterruptedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RadioInterruptedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RadioInterruptedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3537,9 +3537,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Radio.ScanCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ScanCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ScanCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3547,9 +3547,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Radio.ScanStopped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ScanStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ScanStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3557,9 +3557,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Radio.ScanUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.ScanUpdatedEventArgs)> ScanUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.ScanUpdatedEventArgs>, (object, global::Tizen.Multimedia.ScanUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.ScanUpdatedEventArgs> ScanUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.ScanUpdatedEventArgs>, global::Tizen.Multimedia.ScanUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.ScanUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.ScanUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3584,9 +3584,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.AudioStreamStoring"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.AudioStreamStoringEventArgs)> AudioStreamStoring => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioStreamStoringEventArgs>, (object, global::Tizen.Multimedia.AudioStreamStoringEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.AudioStreamStoringEventArgs> AudioStreamStoring => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioStreamStoringEventArgs>, global::Tizen.Multimedia.AudioStreamStoringEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.AudioStreamStoringEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.AudioStreamStoringEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3594,9 +3594,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.ErrorOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RecordingErrorOccurredEventArgs)> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingErrorOccurredEventArgs>, (object, global::Tizen.Multimedia.RecordingErrorOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RecordingErrorOccurredEventArgs> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingErrorOccurredEventArgs>, global::Tizen.Multimedia.RecordingErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecordingErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecordingErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3604,9 +3604,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.Interrupted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RecorderInterruptedEventArgs)> Interrupted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecorderInterruptedEventArgs>, (object, global::Tizen.Multimedia.RecorderInterruptedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RecorderInterruptedEventArgs> Interrupted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecorderInterruptedEventArgs>, global::Tizen.Multimedia.RecorderInterruptedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecorderInterruptedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecorderInterruptedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3614,9 +3614,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.Interrupting"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RecorderInterruptingEventArgs)> Interrupting => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecorderInterruptingEventArgs>, (object, global::Tizen.Multimedia.RecorderInterruptingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RecorderInterruptingEventArgs> Interrupting => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecorderInterruptingEventArgs>, global::Tizen.Multimedia.RecorderInterruptingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecorderInterruptingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecorderInterruptingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3624,9 +3624,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.MuxedStreamDelivered"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.MuxedStreamDeliveredEventArgs)> MuxedStreamDelivered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MuxedStreamDeliveredEventArgs>, (object, global::Tizen.Multimedia.MuxedStreamDeliveredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.MuxedStreamDeliveredEventArgs> MuxedStreamDelivered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MuxedStreamDeliveredEventArgs>, global::Tizen.Multimedia.MuxedStreamDeliveredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.MuxedStreamDeliveredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.MuxedStreamDeliveredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3634,9 +3634,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.RecordingLimitReached"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RecordingLimitReachedEventArgs)> RecordingLimitReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingLimitReachedEventArgs>, (object, global::Tizen.Multimedia.RecordingLimitReachedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RecordingLimitReachedEventArgs> RecordingLimitReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingLimitReachedEventArgs>, global::Tizen.Multimedia.RecordingLimitReachedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecordingLimitReachedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecordingLimitReachedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3644,9 +3644,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.RecordingStatusChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RecordingStatusChangedEventArgs)> RecordingStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingStatusChangedEventArgs>, (object, global::Tizen.Multimedia.RecordingStatusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RecordingStatusChangedEventArgs> RecordingStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingStatusChangedEventArgs>, global::Tizen.Multimedia.RecordingStatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecordingStatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecordingStatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3654,9 +3654,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RecorderStateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecorderStateChangedEventArgs>, (object, global::Tizen.Multimedia.RecorderStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RecorderStateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecorderStateChangedEventArgs>, global::Tizen.Multimedia.RecorderStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecorderStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecorderStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3681,9 +3681,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.StreamRecorder.BufferConsumed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.StreamRecorderBufferConsumedEventArgs)> BufferConsumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.StreamRecorderBufferConsumedEventArgs>, (object, global::Tizen.Multimedia.StreamRecorderBufferConsumedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.StreamRecorderBufferConsumedEventArgs> BufferConsumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.StreamRecorderBufferConsumedEventArgs>, global::Tizen.Multimedia.StreamRecorderBufferConsumedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.StreamRecorderBufferConsumedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.StreamRecorderBufferConsumedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3691,9 +3691,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.StreamRecorder.ErrorOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.StreamRecorderErrorOccurredEventArgs)> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.StreamRecorderErrorOccurredEventArgs>, (object, global::Tizen.Multimedia.StreamRecorderErrorOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.StreamRecorderErrorOccurredEventArgs> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.StreamRecorderErrorOccurredEventArgs>, global::Tizen.Multimedia.StreamRecorderErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.StreamRecorderErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.StreamRecorderErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3701,9 +3701,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.StreamRecorder.RecordingLimitReached"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RecordingLimitReachedEventArgs)> RecordingLimitReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingLimitReachedEventArgs>, (object, global::Tizen.Multimedia.RecordingLimitReachedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RecordingLimitReachedEventArgs> RecordingLimitReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingLimitReachedEventArgs>, global::Tizen.Multimedia.RecordingLimitReachedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecordingLimitReachedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecordingLimitReachedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3711,9 +3711,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.StreamRecorder.RecordingStatusChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.RecordingStatusChangedEventArgs)> RecordingStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingStatusChangedEventArgs>, (object, global::Tizen.Multimedia.RecordingStatusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.RecordingStatusChangedEventArgs> RecordingStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecordingStatusChangedEventArgs>, global::Tizen.Multimedia.RecordingStatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecordingStatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecordingStatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3721,9 +3721,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.StreamRecorder.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.StreamRecorderStateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.StreamRecorderStateChangedEventArgs>, (object, global::Tizen.Multimedia.StreamRecorderStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.StreamRecorderStateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.StreamRecorderStateChangedEventArgs>, global::Tizen.Multimedia.StreamRecorderStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.StreamRecorderStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.StreamRecorderStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3762,9 +3762,9 @@ namespace Tizen.Multimedia.MediaCodec
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.MediaCodec.MediaCodec.BufferStatusChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.MediaCodec.BufferStatusChangedEventArgs)> BufferStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaCodec.BufferStatusChangedEventArgs>, (object, global::Tizen.Multimedia.MediaCodec.BufferStatusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.MediaCodec.BufferStatusChangedEventArgs> BufferStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaCodec.BufferStatusChangedEventArgs>, global::Tizen.Multimedia.MediaCodec.BufferStatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.MediaCodec.BufferStatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.MediaCodec.BufferStatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3772,9 +3772,9 @@ namespace Tizen.Multimedia.MediaCodec
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.MediaCodec.MediaCodec.EosReached"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> EosReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> EosReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3782,9 +3782,9 @@ namespace Tizen.Multimedia.MediaCodec
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.MediaCodec.MediaCodec.ErrorOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.MediaCodec.MediaCodecErrorOccurredEventArgs)> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaCodec.MediaCodecErrorOccurredEventArgs>, (object, global::Tizen.Multimedia.MediaCodec.MediaCodecErrorOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.MediaCodec.MediaCodecErrorOccurredEventArgs> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaCodec.MediaCodecErrorOccurredEventArgs>, global::Tizen.Multimedia.MediaCodec.MediaCodecErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.MediaCodec.MediaCodecErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.MediaCodec.MediaCodecErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3792,9 +3792,9 @@ namespace Tizen.Multimedia.MediaCodec
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.MediaCodec.MediaCodec.InputProcessed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.MediaCodec.InputProcessedEventArgs)> InputProcessed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaCodec.InputProcessedEventArgs>, (object, global::Tizen.Multimedia.MediaCodec.InputProcessedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.MediaCodec.InputProcessedEventArgs> InputProcessed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaCodec.InputProcessedEventArgs>, global::Tizen.Multimedia.MediaCodec.InputProcessedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.MediaCodec.InputProcessedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.MediaCodec.InputProcessedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3802,9 +3802,9 @@ namespace Tizen.Multimedia.MediaCodec
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.MediaCodec.MediaCodec.OutputAvailable"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.MediaCodec.OutputAvailableEventArgs)> OutputAvailable => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaCodec.OutputAvailableEventArgs>, (object, global::Tizen.Multimedia.MediaCodec.OutputAvailableEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.MediaCodec.OutputAvailableEventArgs> OutputAvailable => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.MediaCodec.OutputAvailableEventArgs>, global::Tizen.Multimedia.MediaCodec.OutputAvailableEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.MediaCodec.OutputAvailableEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.MediaCodec.OutputAvailableEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3851,9 +3851,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.MediaController.MetadataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.MetadataUpdatedEventArgs)> MetadataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.MetadataUpdatedEventArgs>, (object, global::Tizen.Multimedia.Remoting.MetadataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Remoting.MetadataUpdatedEventArgs> MetadataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.MetadataUpdatedEventArgs>, global::Tizen.Multimedia.Remoting.MetadataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.MetadataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.MetadataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3861,9 +3861,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.MediaController.PlaybackStateUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.PlaybackStateUpdatedEventArgs)> PlaybackStateUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.PlaybackStateUpdatedEventArgs>, (object, global::Tizen.Multimedia.Remoting.PlaybackStateUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Remoting.PlaybackStateUpdatedEventArgs> PlaybackStateUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.PlaybackStateUpdatedEventArgs>, global::Tizen.Multimedia.Remoting.PlaybackStateUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.PlaybackStateUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.PlaybackStateUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3871,9 +3871,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.MediaController.RepeatModeUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.RepeatModeUpdatedEventArgs)> RepeatModeUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.RepeatModeUpdatedEventArgs>, (object, global::Tizen.Multimedia.Remoting.RepeatModeUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Remoting.RepeatModeUpdatedEventArgs> RepeatModeUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.RepeatModeUpdatedEventArgs>, global::Tizen.Multimedia.Remoting.RepeatModeUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.RepeatModeUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.RepeatModeUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3881,9 +3881,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.MediaController.ServerStopped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ServerStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ServerStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3891,9 +3891,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.MediaController.ShuffleModeUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.ShuffleModeUpdatedEventArgs)> ShuffleModeUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.ShuffleModeUpdatedEventArgs>, (object, global::Tizen.Multimedia.Remoting.ShuffleModeUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Remoting.ShuffleModeUpdatedEventArgs> ShuffleModeUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.ShuffleModeUpdatedEventArgs>, global::Tizen.Multimedia.Remoting.ShuffleModeUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.ShuffleModeUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.ShuffleModeUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3918,9 +3918,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.MediaControllerManager.ServerStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.MediaControlServerStartedEventArgs)> ServerStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.MediaControlServerStartedEventArgs>, (object, global::Tizen.Multimedia.Remoting.MediaControlServerStartedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Remoting.MediaControlServerStartedEventArgs> ServerStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.MediaControlServerStartedEventArgs>, global::Tizen.Multimedia.Remoting.MediaControlServerStartedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.MediaControlServerStartedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.MediaControlServerStartedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3928,9 +3928,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.MediaControllerManager.ServerStopped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.MediaControlServerStoppedEventArgs)> ServerStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.MediaControlServerStoppedEventArgs>, (object, global::Tizen.Multimedia.Remoting.MediaControlServerStoppedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Remoting.MediaControlServerStoppedEventArgs> ServerStopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.MediaControlServerStoppedEventArgs>, global::Tizen.Multimedia.Remoting.MediaControlServerStoppedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.MediaControlServerStoppedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.MediaControlServerStoppedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3955,9 +3955,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.ScreenMirroring.ErrorOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.ScreenMirroringErrorOccurredEventArgs)> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.ScreenMirroringErrorOccurredEventArgs>, (object, global::Tizen.Multimedia.Remoting.ScreenMirroringErrorOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Remoting.ScreenMirroringErrorOccurredEventArgs> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.ScreenMirroringErrorOccurredEventArgs>, global::Tizen.Multimedia.Remoting.ScreenMirroringErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.ScreenMirroringErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.ScreenMirroringErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3965,9 +3965,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.ScreenMirroring.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.ScreenMirroringStateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.ScreenMirroringStateChangedEventArgs>, (object, global::Tizen.Multimedia.Remoting.ScreenMirroringStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Remoting.ScreenMirroringStateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.ScreenMirroringStateChangedEventArgs>, global::Tizen.Multimedia.Remoting.ScreenMirroringStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.ScreenMirroringStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.ScreenMirroringStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4014,9 +4014,9 @@ namespace Tizen.Multimedia.Vision
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Vision.MovementDetector.Detected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Vision.MovementDetectedEventArgs)> Detected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Vision.MovementDetectedEventArgs>, (object, global::Tizen.Multimedia.Vision.MovementDetectedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Vision.MovementDetectedEventArgs> Detected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Vision.MovementDetectedEventArgs>, global::Tizen.Multimedia.Vision.MovementDetectedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Vision.MovementDetectedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Vision.MovementDetectedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4041,9 +4041,9 @@ namespace Tizen.Multimedia.Vision
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Vision.PersonAppearanceDetector.Detected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Vision.PersonAppearanceDetectedEventArgs)> Detected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Vision.PersonAppearanceDetectedEventArgs>, (object, global::Tizen.Multimedia.Vision.PersonAppearanceDetectedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Vision.PersonAppearanceDetectedEventArgs> Detected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Vision.PersonAppearanceDetectedEventArgs>, global::Tizen.Multimedia.Vision.PersonAppearanceDetectedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Vision.PersonAppearanceDetectedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Vision.PersonAppearanceDetectedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4068,9 +4068,9 @@ namespace Tizen.Multimedia.Vision
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Vision.PersonRecognizer.Recognized"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Multimedia.Vision.PersonRecognizedEventArgs)> Recognized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Vision.PersonRecognizedEventArgs>, (object, global::Tizen.Multimedia.Vision.PersonRecognizedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Multimedia.Vision.PersonRecognizedEventArgs> Recognized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Vision.PersonRecognizedEventArgs>, global::Tizen.Multimedia.Vision.PersonRecognizedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Vision.PersonRecognizedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Vision.PersonRecognizedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4157,9 +4157,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAudio.AudioConnectionStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.AudioConnectionStateChangedEventArgs)> AudioConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AudioConnectionStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.AudioConnectionStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.AudioConnectionStateChangedEventArgs> AudioConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AudioConnectionStateChangedEventArgs>, global::Tizen.Network.Bluetooth.AudioConnectionStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.AudioConnectionStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.AudioConnectionStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4184,9 +4184,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAvrcp.EqualizerStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.EqualizerStateChangedEventArgs)> EqualizerStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.EqualizerStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.EqualizerStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.EqualizerStateChangedEventArgs> EqualizerStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.EqualizerStateChangedEventArgs>, global::Tizen.Network.Bluetooth.EqualizerStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.EqualizerStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.EqualizerStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4194,9 +4194,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAvrcp.RepeatModeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.RepeatModeChangedEventArgs)> RepeatModeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.RepeatModeChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.RepeatModeChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.RepeatModeChangedEventArgs> RepeatModeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.RepeatModeChangedEventArgs>, global::Tizen.Network.Bluetooth.RepeatModeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.RepeatModeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.RepeatModeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4204,9 +4204,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAvrcp.ScanModeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.ScanModeChangedEventArgs)> ScanModeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ScanModeChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.ScanModeChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.ScanModeChangedEventArgs> ScanModeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ScanModeChangedEventArgs>, global::Tizen.Network.Bluetooth.ScanModeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.ScanModeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.ScanModeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4214,9 +4214,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAvrcp.ShuffleModeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.ShuffleModeChangedeventArgs)> ShuffleModeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ShuffleModeChangedeventArgs>, (object, global::Tizen.Network.Bluetooth.ShuffleModeChangedeventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.ShuffleModeChangedeventArgs> ShuffleModeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ShuffleModeChangedeventArgs>, global::Tizen.Network.Bluetooth.ShuffleModeChangedeventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.ShuffleModeChangedeventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.ShuffleModeChangedeventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4224,9 +4224,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAvrcp.TargetConnectionStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.TargetConnectionStateChangedEventArgs)> TargetConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.TargetConnectionStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.TargetConnectionStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.TargetConnectionStateChangedEventArgs> TargetConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.TargetConnectionStateChangedEventArgs>, global::Tizen.Network.Bluetooth.TargetConnectionStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.TargetConnectionStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.TargetConnectionStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4251,9 +4251,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothDevice.AuthorizationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.AuthorizationChangedEventArgs)> AuthorizationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AuthorizationChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.AuthorizationChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.AuthorizationChangedEventArgs> AuthorizationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AuthorizationChangedEventArgs>, global::Tizen.Network.Bluetooth.AuthorizationChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.AuthorizationChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.AuthorizationChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4261,9 +4261,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothDevice.BondCreated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.BondCreatedEventArgs)> BondCreated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.BondCreatedEventArgs>, (object, global::Tizen.Network.Bluetooth.BondCreatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.BondCreatedEventArgs> BondCreated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.BondCreatedEventArgs>, global::Tizen.Network.Bluetooth.BondCreatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.BondCreatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.BondCreatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4271,9 +4271,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothDevice.BondDestroyed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.BondDestroyedEventArgs)> BondDestroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.BondDestroyedEventArgs>, (object, global::Tizen.Network.Bluetooth.BondDestroyedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.BondDestroyedEventArgs> BondDestroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.BondDestroyedEventArgs>, global::Tizen.Network.Bluetooth.BondDestroyedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.BondDestroyedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.BondDestroyedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4281,9 +4281,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothDevice.ConnectionStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.DeviceConnectionStateChangedEventArgs)> ConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.DeviceConnectionStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.DeviceConnectionStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.DeviceConnectionStateChangedEventArgs> ConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.DeviceConnectionStateChangedEventArgs>, global::Tizen.Network.Bluetooth.DeviceConnectionStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.DeviceConnectionStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.DeviceConnectionStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4291,9 +4291,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothDevice.ServiceSearched"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.ServiceSearchedEventArgs)> ServiceSearched => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ServiceSearchedEventArgs>, (object, global::Tizen.Network.Bluetooth.ServiceSearchedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.ServiceSearchedEventArgs> ServiceSearched => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ServiceSearchedEventArgs>, global::Tizen.Network.Bluetooth.ServiceSearchedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.ServiceSearchedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.ServiceSearchedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4318,9 +4318,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothGattAttribute.ReadRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.ReadRequestedEventArgs)> ReadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ReadRequestedEventArgs>, (object, global::Tizen.Network.Bluetooth.ReadRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.ReadRequestedEventArgs> ReadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ReadRequestedEventArgs>, global::Tizen.Network.Bluetooth.ReadRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.ReadRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.ReadRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4328,9 +4328,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothGattAttribute.WriteRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.WriteRequestedEventArgs)> WriteRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.WriteRequestedEventArgs>, (object, global::Tizen.Network.Bluetooth.WriteRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.WriteRequestedEventArgs> WriteRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.WriteRequestedEventArgs>, global::Tizen.Network.Bluetooth.WriteRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.WriteRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.WriteRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4355,9 +4355,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothGattCharacteristic.NotificationStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.NotificationStateChangedEventArg)> NotificationStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.NotificationStateChangedEventArg>, (object, global::Tizen.Network.Bluetooth.NotificationStateChangedEventArg)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.NotificationStateChangedEventArg> NotificationStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.NotificationStateChangedEventArg>, global::Tizen.Network.Bluetooth.NotificationStateChangedEventArg>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.NotificationStateChangedEventArg e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.NotificationStateChangedEventArg e) => eventHandler(e);
             return Handler;
         }
 
@@ -4365,9 +4365,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothGattCharacteristic.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.ValueChangedEventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ValueChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.ValueChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.ValueChangedEventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ValueChangedEventArgs>, global::Tizen.Network.Bluetooth.ValueChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.ValueChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.ValueChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4392,9 +4392,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothGattServer.NotificationSent"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.NotificationSentEventArg)> NotificationSent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.NotificationSentEventArg>, (object, global::Tizen.Network.Bluetooth.NotificationSentEventArg)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.NotificationSentEventArg> NotificationSent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.NotificationSentEventArg>, global::Tizen.Network.Bluetooth.NotificationSentEventArg>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.NotificationSentEventArg e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.NotificationSentEventArg e) => eventHandler(e);
             return Handler;
         }
 
@@ -4419,9 +4419,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothHid.HidConnectionStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.HidConnectionStateChangedEventArgs)> HidConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.HidConnectionStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.HidConnectionStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.HidConnectionStateChangedEventArgs> HidConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.HidConnectionStateChangedEventArgs>, global::Tizen.Network.Bluetooth.HidConnectionStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.HidConnectionStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.HidConnectionStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4446,9 +4446,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothLeAdvertiser.AdvertisingStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.AdvertisingStateChangedEventArgs)> AdvertisingStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AdvertisingStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.AdvertisingStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.AdvertisingStateChangedEventArgs> AdvertisingStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AdvertisingStateChangedEventArgs>, global::Tizen.Network.Bluetooth.AdvertisingStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.AdvertisingStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.AdvertisingStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4473,9 +4473,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothLeDevice.GattConnectionStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.GattConnectionStateChangedEventArgs)> GattConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.GattConnectionStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.GattConnectionStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.GattConnectionStateChangedEventArgs> GattConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.GattConnectionStateChangedEventArgs>, global::Tizen.Network.Bluetooth.GattConnectionStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.GattConnectionStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.GattConnectionStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4500,9 +4500,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothOppClient.PushFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.PushFinishedEventArgs)> PushFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.PushFinishedEventArgs>, (object, global::Tizen.Network.Bluetooth.PushFinishedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.PushFinishedEventArgs> PushFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.PushFinishedEventArgs>, global::Tizen.Network.Bluetooth.PushFinishedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.PushFinishedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.PushFinishedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4510,9 +4510,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothOppClient.PushProgress"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.PushProgressEventArgs)> PushProgress => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.PushProgressEventArgs>, (object, global::Tizen.Network.Bluetooth.PushProgressEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.PushProgressEventArgs> PushProgress => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.PushProgressEventArgs>, global::Tizen.Network.Bluetooth.PushProgressEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.PushProgressEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.PushProgressEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4520,9 +4520,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothOppClient.PushResponded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.PushRespondedEventArgs)> PushResponded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.PushRespondedEventArgs>, (object, global::Tizen.Network.Bluetooth.PushRespondedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.PushRespondedEventArgs> PushResponded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.PushRespondedEventArgs>, global::Tizen.Network.Bluetooth.PushRespondedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.PushRespondedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.PushRespondedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4547,9 +4547,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothOppServer.ConnectionRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.ConnectionRequestedEventArgs)> ConnectionRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ConnectionRequestedEventArgs>, (object, global::Tizen.Network.Bluetooth.ConnectionRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.ConnectionRequestedEventArgs> ConnectionRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.ConnectionRequestedEventArgs>, global::Tizen.Network.Bluetooth.ConnectionRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.ConnectionRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.ConnectionRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4557,9 +4557,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothOppServer.TransferFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.TransferFinishedEventArgs)> TransferFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.TransferFinishedEventArgs>, (object, global::Tizen.Network.Bluetooth.TransferFinishedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.TransferFinishedEventArgs> TransferFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.TransferFinishedEventArgs>, global::Tizen.Network.Bluetooth.TransferFinishedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.TransferFinishedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.TransferFinishedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4567,9 +4567,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothOppServer.TransferProgress"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.TransferProgressEventArgs)> TransferProgress => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.TransferProgressEventArgs>, (object, global::Tizen.Network.Bluetooth.TransferProgressEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.TransferProgressEventArgs> TransferProgress => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.TransferProgressEventArgs>, global::Tizen.Network.Bluetooth.TransferProgressEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.TransferProgressEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.TransferProgressEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4594,9 +4594,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothServerSocket.AcceptStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.AcceptStateChangedEventArgs)> AcceptStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AcceptStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.AcceptStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.AcceptStateChangedEventArgs> AcceptStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AcceptStateChangedEventArgs>, global::Tizen.Network.Bluetooth.AcceptStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.AcceptStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.AcceptStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4621,9 +4621,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.IBluetoothServerSocket.ConnectionStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.SocketConnectionStateChangedEventArgs)> ConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.SocketConnectionStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.SocketConnectionStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.SocketConnectionStateChangedEventArgs> ConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.SocketConnectionStateChangedEventArgs>, global::Tizen.Network.Bluetooth.SocketConnectionStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.SocketConnectionStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.SocketConnectionStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4631,9 +4631,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.IBluetoothServerSocket.DataReceived"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Bluetooth.SocketDataReceivedEventArgs)> DataReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.SocketDataReceivedEventArgs>, (object, global::Tizen.Network.Bluetooth.SocketDataReceivedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Bluetooth.SocketDataReceivedEventArgs> DataReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.SocketDataReceivedEventArgs>, global::Tizen.Network.Bluetooth.SocketDataReceivedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.SocketDataReceivedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.SocketDataReceivedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4672,9 +4672,9 @@ namespace Tizen.Network.Connection
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Connection.ConnectionProfile.ProfileStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Connection.ProfileStateEventArgs)> ProfileStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.ProfileStateEventArgs>, (object, global::Tizen.Network.Connection.ProfileStateEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Connection.ProfileStateEventArgs> ProfileStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.ProfileStateEventArgs>, global::Tizen.Network.Connection.ProfileStateEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Connection.ProfileStateEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Connection.ProfileStateEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4713,9 +4713,9 @@ namespace Tizen.Network.IoTConnectivity
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.IoTConnectivity.RemoteResource.CacheUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.IoTConnectivity.CacheUpdatedEventArgs)> CacheUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.CacheUpdatedEventArgs>, (object, global::Tizen.Network.IoTConnectivity.CacheUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.IoTConnectivity.CacheUpdatedEventArgs> CacheUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.CacheUpdatedEventArgs>, global::Tizen.Network.IoTConnectivity.CacheUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.IoTConnectivity.CacheUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.IoTConnectivity.CacheUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4723,9 +4723,9 @@ namespace Tizen.Network.IoTConnectivity
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.IoTConnectivity.RemoteResource.ObserverNotified"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.IoTConnectivity.ObserverNotifiedEventArgs)> ObserverNotified => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.ObserverNotifiedEventArgs>, (object, global::Tizen.Network.IoTConnectivity.ObserverNotifiedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.IoTConnectivity.ObserverNotifiedEventArgs> ObserverNotified => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.ObserverNotifiedEventArgs>, global::Tizen.Network.IoTConnectivity.ObserverNotifiedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.IoTConnectivity.ObserverNotifiedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.IoTConnectivity.ObserverNotifiedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4733,9 +4733,9 @@ namespace Tizen.Network.IoTConnectivity
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.IoTConnectivity.RemoteResource.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.IoTConnectivity.StateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.StateChangedEventArgs>, (object, global::Tizen.Network.IoTConnectivity.StateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.IoTConnectivity.StateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.StateChangedEventArgs>, global::Tizen.Network.IoTConnectivity.StateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.IoTConnectivity.StateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.IoTConnectivity.StateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4786,9 +4786,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcCardEmulationAdapter.EseSecureElementTransactionEvent"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs)> EseSecureElementTransactionEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.SecureElementTranscationEventArgs>, (object, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nfc.SecureElementTranscationEventArgs> EseSecureElementTransactionEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.SecureElementTranscationEventArgs>, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4796,9 +4796,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcCardEmulationAdapter.HostCardEmulationEvent"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nfc.HostCardEmulationEventArgs)> HostCardEmulationEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.HostCardEmulationEventArgs>, (object, global::Tizen.Network.Nfc.HostCardEmulationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nfc.HostCardEmulationEventArgs> HostCardEmulationEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.HostCardEmulationEventArgs>, global::Tizen.Network.Nfc.HostCardEmulationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.HostCardEmulationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.HostCardEmulationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4806,9 +4806,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcCardEmulationAdapter.SecureElementEvent"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nfc.SecureElementEventArgs)> SecureElementEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.SecureElementEventArgs>, (object, global::Tizen.Network.Nfc.SecureElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nfc.SecureElementEventArgs> SecureElementEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.SecureElementEventArgs>, global::Tizen.Network.Nfc.SecureElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.SecureElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.SecureElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4816,9 +4816,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcCardEmulationAdapter.UiccSecureElementTransactionEvent"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs)> UiccSecureElementTransactionEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.SecureElementTranscationEventArgs>, (object, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nfc.SecureElementTranscationEventArgs> UiccSecureElementTransactionEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.SecureElementTranscationEventArgs>, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.SecureElementTranscationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4843,9 +4843,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcP2p.P2pDataReceived"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nfc.P2pDataReceivedEventArgs)> P2pDataReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.P2pDataReceivedEventArgs>, (object, global::Tizen.Network.Nfc.P2pDataReceivedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nfc.P2pDataReceivedEventArgs> P2pDataReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.P2pDataReceivedEventArgs>, global::Tizen.Network.Nfc.P2pDataReceivedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.P2pDataReceivedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.P2pDataReceivedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4870,9 +4870,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcP2pAdapter.P2pTargetDiscovered"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nfc.P2pTargetDiscoveredEventArgs)> P2pTargetDiscovered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.P2pTargetDiscoveredEventArgs>, (object, global::Tizen.Network.Nfc.P2pTargetDiscoveredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nfc.P2pTargetDiscoveredEventArgs> P2pTargetDiscovered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.P2pTargetDiscoveredEventArgs>, global::Tizen.Network.Nfc.P2pTargetDiscoveredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.P2pTargetDiscoveredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.P2pTargetDiscoveredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4897,9 +4897,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcTagAdapter.TagDiscovered"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nfc.TagDiscoveredEventArgs)> TagDiscovered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.TagDiscoveredEventArgs>, (object, global::Tizen.Network.Nfc.TagDiscoveredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nfc.TagDiscoveredEventArgs> TagDiscovered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.TagDiscoveredEventArgs>, global::Tizen.Network.Nfc.TagDiscoveredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.TagDiscoveredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.TagDiscoveredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4942,9 +4942,9 @@ namespace Tizen.Network.Nsd
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nsd.DnssdBrowser.ServiceFound"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nsd.DnssdServiceFoundEventArgs)> ServiceFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nsd.DnssdServiceFoundEventArgs>, (object, global::Tizen.Network.Nsd.DnssdServiceFoundEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nsd.DnssdServiceFoundEventArgs> ServiceFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nsd.DnssdServiceFoundEventArgs>, global::Tizen.Network.Nsd.DnssdServiceFoundEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nsd.DnssdServiceFoundEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nsd.DnssdServiceFoundEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -4969,9 +4969,9 @@ namespace Tizen.Network.Nsd
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nsd.SsdpBrowser.ServiceFound"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.Nsd.SsdpServiceFoundEventArgs)> ServiceFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nsd.SsdpServiceFoundEventArgs>, (object, global::Tizen.Network.Nsd.SsdpServiceFoundEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.Nsd.SsdpServiceFoundEventArgs> ServiceFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nsd.SsdpServiceFoundEventArgs>, global::Tizen.Network.Nsd.SsdpServiceFoundEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nsd.SsdpServiceFoundEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nsd.SsdpServiceFoundEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5010,9 +5010,9 @@ namespace Tizen.Network.WiFiDirect
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFiDirect.WiFiDirectPeer.ConnectionStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.WiFiDirect.ConnectionStateChangedEventArgs)> ConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.ConnectionStateChangedEventArgs>, (object, global::Tizen.Network.WiFiDirect.ConnectionStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.WiFiDirect.ConnectionStateChangedEventArgs> ConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.ConnectionStateChangedEventArgs>, global::Tizen.Network.WiFiDirect.ConnectionStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFiDirect.ConnectionStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFiDirect.ConnectionStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5020,9 +5020,9 @@ namespace Tizen.Network.WiFiDirect
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFiDirect.WiFiDirectPeer.IpAddressAssigned"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.WiFiDirect.IpAddressAssignedEventArgs)> IpAddressAssigned => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.IpAddressAssignedEventArgs>, (object, global::Tizen.Network.WiFiDirect.IpAddressAssignedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.WiFiDirect.IpAddressAssignedEventArgs> IpAddressAssigned => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.IpAddressAssignedEventArgs>, global::Tizen.Network.WiFiDirect.IpAddressAssignedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFiDirect.IpAddressAssignedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFiDirect.IpAddressAssignedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5030,9 +5030,9 @@ namespace Tizen.Network.WiFiDirect
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFiDirect.WiFiDirectPeer.ServiceStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Network.WiFiDirect.ServiceStateChangedEventArgs)> ServiceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.ServiceStateChangedEventArgs>, (object, global::Tizen.Network.WiFiDirect.ServiceStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Network.WiFiDirect.ServiceStateChangedEventArgs> ServiceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.ServiceStateChangedEventArgs>, global::Tizen.Network.WiFiDirect.ServiceStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFiDirect.ServiceStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFiDirect.ServiceStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5111,9 +5111,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.Animation.Finished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Finished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Finished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5121,9 +5121,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.Animation.ProgressReached"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ProgressReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ProgressReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5148,9 +5148,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.FocusManager.FocusChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.FocusManager.FocusChangedEventArgs)> FocusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.FocusManager.FocusChangedEventArgs>, (object, global::Tizen.NUI.FocusManager.FocusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.FocusManager.FocusChangedEventArgs> FocusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.FocusManager.FocusChangedEventArgs>, global::Tizen.NUI.FocusManager.FocusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.FocusManager.FocusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.FocusManager.FocusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5158,9 +5158,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.FocusManager.FocusedViewActivated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.FocusManager.FocusedViewActivatedEventArgs)> FocusedViewActivated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.FocusManager.FocusedViewActivatedEventArgs>, (object, global::Tizen.NUI.FocusManager.FocusedViewActivatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.FocusManager.FocusedViewActivatedEventArgs> FocusedViewActivated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.FocusManager.FocusedViewActivatedEventArgs>, global::Tizen.NUI.FocusManager.FocusedViewActivatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.FocusManager.FocusedViewActivatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.FocusManager.FocusedViewActivatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5169,9 +5169,9 @@ namespace Tizen.NUI
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.FocusManager.FocusedViewEnterKeyPressed"/> event triggers.
         /// </summary>
         [global::System.ObsoleteAttribute("Please do not use! This will be deprecated! Please use FocusManager.FocusedViewActivated instead! Like: FocusManager.Instance.FocusedViewActivated = OnFocusedViewActivated; private void OnFocusedViewActivated(object source, FocusManager.FocusedViewActivatedEventArgs args) {...}", false)]
-        public global::System.IObservable<(object, global::Tizen.NUI.FocusManager.FocusedViewEnterKeyEventArgs)> FocusedViewEnterKeyPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.FocusManager.FocusedViewEnterKeyEventArgs>, (object, global::Tizen.NUI.FocusManager.FocusedViewEnterKeyEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.FocusManager.FocusedViewEnterKeyEventArgs> FocusedViewEnterKeyPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.FocusManager.FocusedViewEnterKeyEventArgs>, global::Tizen.NUI.FocusManager.FocusedViewEnterKeyEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.FocusManager.FocusedViewEnterKeyEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.FocusManager.FocusedViewEnterKeyEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5179,9 +5179,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.FocusManager.FocusGroupChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.FocusManager.FocusGroupChangedEventArgs)> FocusGroupChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.FocusManager.FocusGroupChangedEventArgs>, (object, global::Tizen.NUI.FocusManager.FocusGroupChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.FocusManager.FocusGroupChangedEventArgs> FocusGroupChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.FocusManager.FocusGroupChangedEventArgs>, global::Tizen.NUI.FocusManager.FocusGroupChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.FocusManager.FocusGroupChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.FocusManager.FocusGroupChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5206,9 +5206,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.ImfManager.Activated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.ImfManager.ActivatedEventArgs)> Activated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.ActivatedEventArgs>, (object, global::Tizen.NUI.ImfManager.ActivatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.ImfManager.ActivatedEventArgs> Activated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.ActivatedEventArgs>, global::Tizen.NUI.ImfManager.ActivatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.ImfManager.ActivatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.ImfManager.ActivatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5216,9 +5216,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.ImfManager.KeyboardTypeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.ImfManager.KeyboardTypeChangedEventArgs)> KeyboardTypeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.KeyboardTypeChangedEventArgs>, (object, global::Tizen.NUI.ImfManager.KeyboardTypeChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.ImfManager.KeyboardTypeChangedEventArgs> KeyboardTypeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.KeyboardTypeChangedEventArgs>, global::Tizen.NUI.ImfManager.KeyboardTypeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.ImfManager.KeyboardTypeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.ImfManager.KeyboardTypeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5226,9 +5226,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.ImfManager.LanguageChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.ImfManager.LanguageChangedEventArgs)> LanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.LanguageChangedEventArgs>, (object, global::Tizen.NUI.ImfManager.LanguageChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.ImfManager.LanguageChangedEventArgs> LanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.LanguageChangedEventArgs>, global::Tizen.NUI.ImfManager.LanguageChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.ImfManager.LanguageChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.ImfManager.LanguageChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5236,9 +5236,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.ImfManager.Resized"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.ImfManager.ResizedEventArgs)> Resized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.ResizedEventArgs>, (object, global::Tizen.NUI.ImfManager.ResizedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.ImfManager.ResizedEventArgs> Resized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.ResizedEventArgs>, global::Tizen.NUI.ImfManager.ResizedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.ImfManager.ResizedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.ImfManager.ResizedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5246,9 +5246,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.ImfManager.StatusChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.ImfManager.StatusChangedEventArgs)> StatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.StatusChangedEventArgs>, (object, global::Tizen.NUI.ImfManager.StatusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.ImfManager.StatusChangedEventArgs> StatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.ImfManager.StatusChangedEventArgs>, global::Tizen.NUI.ImfManager.StatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.ImfManager.StatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.ImfManager.StatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5273,9 +5273,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.NUIApplication.Paused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Paused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Paused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5283,9 +5283,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.NUIApplication.Resumed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Resumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Resumed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5310,9 +5310,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.PropertyNotification.Notified"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.PropertyNotification.NotifyEventArgs)> Notified => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.PropertyNotification.NotifyEventArgs>, (object, global::Tizen.NUI.PropertyNotification.NotifyEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.PropertyNotification.NotifyEventArgs> Notified => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.PropertyNotification.NotifyEventArgs>, global::Tizen.NUI.PropertyNotification.NotifyEventArgs>(eventHandler =>
         {
-            void Handler(object source, global::Tizen.NUI.PropertyNotification.NotifyEventArgs e) => eventHandler((source, e));
+            void Handler(object source, global::Tizen.NUI.PropertyNotification.NotifyEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5337,9 +5337,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.ScrollView.SnapStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.ScrollView.SnapStartedEventArgs)> SnapStarted => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.ScrollView.SnapStartedEventArgs>, (object, global::Tizen.NUI.ScrollView.SnapStartedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.ScrollView.SnapStartedEventArgs> SnapStarted => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.ScrollView.SnapStartedEventArgs>, global::Tizen.NUI.ScrollView.SnapStartedEventArgs>(eventHandler =>
         {
-            void Handler(object source, global::Tizen.NUI.ScrollView.SnapStartedEventArgs e) => eventHandler((source, e));
+            void Handler(object source, global::Tizen.NUI.ScrollView.SnapStartedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5364,9 +5364,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.StyleManager.StyleChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.StyleManager.StyleChangedEventArgs)> StyleChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.StyleManager.StyleChangedEventArgs>, (object, global::Tizen.NUI.StyleManager.StyleChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.StyleManager.StyleChangedEventArgs> StyleChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.StyleManager.StyleChangedEventArgs>, global::Tizen.NUI.StyleManager.StyleChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.StyleManager.StyleChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.StyleManager.StyleChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5407,9 +5407,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.TTSPlayer.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.TTSPlayer.StateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.TTSPlayer.StateChangedEventArgs>, (object, global::Tizen.NUI.TTSPlayer.StateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.TTSPlayer.StateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.TTSPlayer.StateChangedEventArgs>, global::Tizen.NUI.TTSPlayer.StateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.TTSPlayer.StateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.TTSPlayer.StateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5434,9 +5434,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.WidgetView.WidgetAdded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)> WidgetAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, (object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.WidgetView.WidgetViewEventArgs> WidgetAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, global::Tizen.NUI.WidgetView.WidgetViewEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5444,9 +5444,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.WidgetView.WidgetContentUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)> WidgetContentUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, (object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.WidgetView.WidgetViewEventArgs> WidgetContentUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, global::Tizen.NUI.WidgetView.WidgetViewEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5454,9 +5454,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.WidgetView.WidgetCreationAborted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)> WidgetCreationAborted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, (object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.WidgetView.WidgetViewEventArgs> WidgetCreationAborted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, global::Tizen.NUI.WidgetView.WidgetViewEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5464,9 +5464,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.WidgetView.WidgetDeleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)> WidgetDeleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, (object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.WidgetView.WidgetViewEventArgs> WidgetDeleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, global::Tizen.NUI.WidgetView.WidgetViewEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5474,9 +5474,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.WidgetView.WidgetFaulted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)> WidgetFaulted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, (object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.WidgetView.WidgetViewEventArgs> WidgetFaulted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, global::Tizen.NUI.WidgetView.WidgetViewEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5484,9 +5484,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.WidgetView.WidgetUpdatePeriodChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)> WidgetUpdatePeriodChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, (object, global::Tizen.NUI.WidgetView.WidgetViewEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.WidgetView.WidgetViewEventArgs> WidgetUpdatePeriodChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.WidgetView.WidgetViewEventArgs>, global::Tizen.NUI.WidgetView.WidgetViewEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.WidgetView.WidgetViewEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5511,9 +5511,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.Window.FocusChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.Window.FocusChangedEventArgs)> FocusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.FocusChangedEventArgs>, (object, global::Tizen.NUI.Window.FocusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.Window.FocusChangedEventArgs> FocusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.FocusChangedEventArgs>, global::Tizen.NUI.Window.FocusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.Window.FocusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.Window.FocusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5521,9 +5521,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.Window.KeyEvent"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.Window.KeyEventArgs)> KeyEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.KeyEventArgs>, (object, global::Tizen.NUI.Window.KeyEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.Window.KeyEventArgs> KeyEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.KeyEventArgs>, global::Tizen.NUI.Window.KeyEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.Window.KeyEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.Window.KeyEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5531,9 +5531,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.Window.Resized"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.Window.ResizedEventArgs)> Resized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.ResizedEventArgs>, (object, global::Tizen.NUI.Window.ResizedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.Window.ResizedEventArgs> Resized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.ResizedEventArgs>, global::Tizen.NUI.Window.ResizedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.Window.ResizedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.Window.ResizedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5541,9 +5541,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.Window.TouchEvent"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.Window.TouchEventArgs)> TouchEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.TouchEventArgs>, (object, global::Tizen.NUI.Window.TouchEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.Window.TouchEventArgs> TouchEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.TouchEventArgs>, global::Tizen.NUI.Window.TouchEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.Window.TouchEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.Window.TouchEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5551,9 +5551,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.Window.WheelEvent"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.Window.WheelEventArgs)> WheelEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.WheelEventArgs>, (object, global::Tizen.NUI.Window.WheelEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.Window.WheelEventArgs> WheelEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.WheelEventArgs>, global::Tizen.NUI.Window.WheelEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.Window.WheelEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.Window.WheelEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5562,9 +5562,9 @@ namespace Tizen.NUI
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.Window.WindowFocusChanged"/> event triggers.
         /// </summary>
         [global::System.ObsoleteAttribute("Please do not use! This will be deprecated! Please use FocusChanged instead! Like: Window.Instance.FocusChanged = OnFocusChanged; private void OnFocusChanged(object source, Window.FocusChangedEventArgs args) {...}", false)]
-        public global::System.IObservable<(object, global::Tizen.NUI.Window.WindowFocusChangedEventArgs)> WindowFocusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.WindowFocusChangedEventArgs>, (object, global::Tizen.NUI.Window.WindowFocusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.Window.WindowFocusChangedEventArgs> WindowFocusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.Window.WindowFocusChangedEventArgs>, global::Tizen.NUI.Window.WindowFocusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.Window.WindowFocusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.Window.WindowFocusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5623,9 +5623,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.ImageView.ResourceReady"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.ImageView.ResourceReadyEventArgs)> ResourceReady => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.ImageView.ResourceReadyEventArgs>, (object, global::Tizen.NUI.BaseComponents.ImageView.ResourceReadyEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.ImageView.ResourceReadyEventArgs> ResourceReady => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.ImageView.ResourceReadyEventArgs>, global::Tizen.NUI.BaseComponents.ImageView.ResourceReadyEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.BaseComponents.ImageView.ResourceReadyEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.BaseComponents.ImageView.ResourceReadyEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5650,9 +5650,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.Scrollable.ScrollCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.Scrollable.CompletedEventArgs)> ScrollCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.BaseComponents.Scrollable.CompletedEventArgs>, (object, global::Tizen.NUI.BaseComponents.Scrollable.CompletedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.Scrollable.CompletedEventArgs> ScrollCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.BaseComponents.Scrollable.CompletedEventArgs>, global::Tizen.NUI.BaseComponents.Scrollable.CompletedEventArgs>(eventHandler =>
         {
-            void Handler(object source, global::Tizen.NUI.BaseComponents.Scrollable.CompletedEventArgs e) => eventHandler((source, e));
+            void Handler(object source, global::Tizen.NUI.BaseComponents.Scrollable.CompletedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5660,9 +5660,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.Scrollable.ScrollStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.Scrollable.StartedEventArgs)> ScrollStarted => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.BaseComponents.Scrollable.StartedEventArgs>, (object, global::Tizen.NUI.BaseComponents.Scrollable.StartedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.Scrollable.StartedEventArgs> ScrollStarted => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.BaseComponents.Scrollable.StartedEventArgs>, global::Tizen.NUI.BaseComponents.Scrollable.StartedEventArgs>(eventHandler =>
         {
-            void Handler(object source, global::Tizen.NUI.BaseComponents.Scrollable.StartedEventArgs e) => eventHandler((source, e));
+            void Handler(object source, global::Tizen.NUI.BaseComponents.Scrollable.StartedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5670,9 +5670,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.Scrollable.ScrollUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.Scrollable.UpdatedEventArgs)> ScrollUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.BaseComponents.Scrollable.UpdatedEventArgs>, (object, global::Tizen.NUI.BaseComponents.Scrollable.UpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.Scrollable.UpdatedEventArgs> ScrollUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::Tizen.NUI.DaliEventHandler<object, global::Tizen.NUI.BaseComponents.Scrollable.UpdatedEventArgs>, global::Tizen.NUI.BaseComponents.Scrollable.UpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object source, global::Tizen.NUI.BaseComponents.Scrollable.UpdatedEventArgs e) => eventHandler((source, e));
+            void Handler(object source, global::Tizen.NUI.BaseComponents.Scrollable.UpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5697,9 +5697,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.TextEditor.ScrollStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.TextEditor.ScrollStateChangedEventArgs)> ScrollStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.TextEditor.ScrollStateChangedEventArgs>, (object, global::Tizen.NUI.BaseComponents.TextEditor.ScrollStateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.TextEditor.ScrollStateChangedEventArgs> ScrollStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.TextEditor.ScrollStateChangedEventArgs>, global::Tizen.NUI.BaseComponents.TextEditor.ScrollStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.BaseComponents.TextEditor.ScrollStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.BaseComponents.TextEditor.ScrollStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5707,9 +5707,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.TextEditor.TextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.TextEditor.TextChangedEventArgs)> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.TextEditor.TextChangedEventArgs>, (object, global::Tizen.NUI.BaseComponents.TextEditor.TextChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.TextEditor.TextChangedEventArgs> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.TextEditor.TextChangedEventArgs>, global::Tizen.NUI.BaseComponents.TextEditor.TextChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.BaseComponents.TextEditor.TextChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.BaseComponents.TextEditor.TextChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5734,9 +5734,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.TextField.MaxLengthReached"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.TextField.MaxLengthReachedEventArgs)> MaxLengthReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.TextField.MaxLengthReachedEventArgs>, (object, global::Tizen.NUI.BaseComponents.TextField.MaxLengthReachedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.TextField.MaxLengthReachedEventArgs> MaxLengthReached => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.TextField.MaxLengthReachedEventArgs>, global::Tizen.NUI.BaseComponents.TextField.MaxLengthReachedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.BaseComponents.TextField.MaxLengthReachedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.BaseComponents.TextField.MaxLengthReachedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5744,9 +5744,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.TextField.TextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.TextField.TextChangedEventArgs)> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.TextField.TextChangedEventArgs>, (object, global::Tizen.NUI.BaseComponents.TextField.TextChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.TextField.TextChangedEventArgs> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.TextField.TextChangedEventArgs>, global::Tizen.NUI.BaseComponents.TextField.TextChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.BaseComponents.TextField.TextChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.BaseComponents.TextField.TextChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5771,9 +5771,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.VideoView.Finished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.VideoView.FinishedEventArgs)> Finished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.VideoView.FinishedEventArgs>, (object, global::Tizen.NUI.BaseComponents.VideoView.FinishedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.VideoView.FinishedEventArgs> Finished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.VideoView.FinishedEventArgs>, global::Tizen.NUI.BaseComponents.VideoView.FinishedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.BaseComponents.VideoView.FinishedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.BaseComponents.VideoView.FinishedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5798,9 +5798,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.View.AddedToWindow"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> AddedToWindow => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> AddedToWindow => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5808,9 +5808,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.View.FocusGained"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> FocusGained => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> FocusGained => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5818,9 +5818,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.View.FocusLost"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> FocusLost => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> FocusLost => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5828,9 +5828,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.View.LayoutDirectionChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.View.LayoutDirectionChangedEventArgs)> LayoutDirectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.View.LayoutDirectionChangedEventArgs>, (object, global::Tizen.NUI.BaseComponents.View.LayoutDirectionChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.View.LayoutDirectionChangedEventArgs> LayoutDirectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.View.LayoutDirectionChangedEventArgs>, global::Tizen.NUI.BaseComponents.View.LayoutDirectionChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.BaseComponents.View.LayoutDirectionChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.BaseComponents.View.LayoutDirectionChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5838,9 +5838,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.View.Relayout"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Relayout => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Relayout => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5848,9 +5848,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.View.RemovedFromWindow"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> RemovedFromWindow => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> RemovedFromWindow => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5858,9 +5858,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.View.ResourcesLoaded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ResourcesLoaded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ResourcesLoaded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5868,9 +5868,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.BaseComponents.View.VisibilityChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.BaseComponents.View.VisibilityChangedEventArgs)> VisibilityChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.View.VisibilityChangedEventArgs>, (object, global::Tizen.NUI.BaseComponents.View.VisibilityChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.BaseComponents.View.VisibilityChangedEventArgs> VisibilityChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.BaseComponents.View.VisibilityChangedEventArgs>, global::Tizen.NUI.BaseComponents.View.VisibilityChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.BaseComponents.View.VisibilityChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.BaseComponents.View.VisibilityChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5941,9 +5941,9 @@ namespace Tizen.NUI.UIComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.UIComponents.Popup.Hidden"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.UIComponents.Popup.HiddenEventArgs)> Hidden => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.HiddenEventArgs>, (object, global::Tizen.NUI.UIComponents.Popup.HiddenEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.UIComponents.Popup.HiddenEventArgs> Hidden => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.HiddenEventArgs>, global::Tizen.NUI.UIComponents.Popup.HiddenEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.HiddenEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.HiddenEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5951,9 +5951,9 @@ namespace Tizen.NUI.UIComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.UIComponents.Popup.Hiding"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.UIComponents.Popup.HidingEventArgs)> Hiding => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.HidingEventArgs>, (object, global::Tizen.NUI.UIComponents.Popup.HidingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.UIComponents.Popup.HidingEventArgs> Hiding => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.HidingEventArgs>, global::Tizen.NUI.UIComponents.Popup.HidingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.HidingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.HidingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5961,9 +5961,9 @@ namespace Tizen.NUI.UIComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.UIComponents.Popup.Showing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.UIComponents.Popup.ShowingEventArgs)> Showing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.ShowingEventArgs>, (object, global::Tizen.NUI.UIComponents.Popup.ShowingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.UIComponents.Popup.ShowingEventArgs> Showing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.ShowingEventArgs>, global::Tizen.NUI.UIComponents.Popup.ShowingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.ShowingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.ShowingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5971,9 +5971,9 @@ namespace Tizen.NUI.UIComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.UIComponents.Popup.Shown"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.UIComponents.Popup.ShownEventArgs)> Shown => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.ShownEventArgs>, (object, global::Tizen.NUI.UIComponents.Popup.ShownEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.UIComponents.Popup.ShownEventArgs> Shown => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.ShownEventArgs>, global::Tizen.NUI.UIComponents.Popup.ShownEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.ShownEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.ShownEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -5981,9 +5981,9 @@ namespace Tizen.NUI.UIComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.UIComponents.Popup.TouchedOutside"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.UIComponents.Popup.TouchedOutsideEventArgs)> TouchedOutside => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.TouchedOutsideEventArgs>, (object, global::Tizen.NUI.UIComponents.Popup.TouchedOutsideEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.UIComponents.Popup.TouchedOutsideEventArgs> TouchedOutside => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.Popup.TouchedOutsideEventArgs>, global::Tizen.NUI.UIComponents.Popup.TouchedOutsideEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.TouchedOutsideEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.UIComponents.Popup.TouchedOutsideEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6008,9 +6008,9 @@ namespace Tizen.NUI.UIComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.UIComponents.ProgressBar.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.UIComponents.ProgressBar.ValueChangedEventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.ProgressBar.ValueChangedEventArgs>, (object, global::Tizen.NUI.UIComponents.ProgressBar.ValueChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.UIComponents.ProgressBar.ValueChangedEventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.ProgressBar.ValueChangedEventArgs>, global::Tizen.NUI.UIComponents.ProgressBar.ValueChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.UIComponents.ProgressBar.ValueChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.UIComponents.ProgressBar.ValueChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6035,9 +6035,9 @@ namespace Tizen.NUI.UIComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.UIComponents.ScrollBar.PanFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.UIComponents.ScrollBar.PanFinishedEventArgs)> PanFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.ScrollBar.PanFinishedEventArgs>, (object, global::Tizen.NUI.UIComponents.ScrollBar.PanFinishedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.UIComponents.ScrollBar.PanFinishedEventArgs> PanFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.ScrollBar.PanFinishedEventArgs>, global::Tizen.NUI.UIComponents.ScrollBar.PanFinishedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.UIComponents.ScrollBar.PanFinishedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.UIComponents.ScrollBar.PanFinishedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6045,9 +6045,9 @@ namespace Tizen.NUI.UIComponents
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.NUI.UIComponents.ScrollBar.ScrollInterval"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.NUI.UIComponents.ScrollBar.ScrollIntervalEventArgs)> ScrollInterval => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.ScrollBar.ScrollIntervalEventArgs>, (object, global::Tizen.NUI.UIComponents.ScrollBar.ScrollIntervalEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.NUI.UIComponents.ScrollBar.ScrollIntervalEventArgs> ScrollInterval => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.NUI.UIComponents.ScrollBar.ScrollIntervalEventArgs>, global::Tizen.NUI.UIComponents.ScrollBar.ScrollIntervalEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.NUI.UIComponents.ScrollBar.ScrollIntervalEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.NUI.UIComponents.ScrollBar.ScrollIntervalEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6106,9 +6106,9 @@ namespace Tizen.Pims.Contacts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Pims.Contacts.ContactsDatabase.DBStatusChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Pims.Contacts.DBStatusChangedEventArgs)> DBStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Pims.Contacts.DBStatusChangedEventArgs>, (object, global::Tizen.Pims.Contacts.DBStatusChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Pims.Contacts.DBStatusChangedEventArgs> DBStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Pims.Contacts.DBStatusChangedEventArgs>, global::Tizen.Pims.Contacts.DBStatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Pims.Contacts.DBStatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Pims.Contacts.DBStatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6133,9 +6133,9 @@ namespace Tizen.Pims.Contacts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Pims.Contacts.ContactsManager.NameDisplayOrderChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Pims.Contacts.NameDisplayOrderChangedEventArgs)> NameDisplayOrderChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Pims.Contacts.NameDisplayOrderChangedEventArgs>, (object, global::Tizen.Pims.Contacts.NameDisplayOrderChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Pims.Contacts.NameDisplayOrderChangedEventArgs> NameDisplayOrderChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Pims.Contacts.NameDisplayOrderChangedEventArgs>, global::Tizen.Pims.Contacts.NameDisplayOrderChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Pims.Contacts.NameDisplayOrderChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Pims.Contacts.NameDisplayOrderChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6143,9 +6143,9 @@ namespace Tizen.Pims.Contacts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Pims.Contacts.ContactsManager.NameSortingOrderChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Pims.Contacts.NameSortingOrderChangedEventArgs)> NameSortingOrderChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Pims.Contacts.NameSortingOrderChangedEventArgs>, (object, global::Tizen.Pims.Contacts.NameSortingOrderChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Pims.Contacts.NameSortingOrderChangedEventArgs> NameSortingOrderChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Pims.Contacts.NameSortingOrderChangedEventArgs>, global::Tizen.Pims.Contacts.NameSortingOrderChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Pims.Contacts.NameSortingOrderChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Pims.Contacts.NameSortingOrderChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6184,9 +6184,9 @@ namespace Tizen.Security
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Security.PrivacyPrivilegeManager.ResponseContext.ResponseFetched"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Security.RequestResponseEventArgs)> ResponseFetched => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Security.RequestResponseEventArgs>, (object, global::Tizen.Security.RequestResponseEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Security.RequestResponseEventArgs> ResponseFetched => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Security.RequestResponseEventArgs>, global::Tizen.Security.RequestResponseEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Security.RequestResponseEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Security.RequestResponseEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6329,9 +6329,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.Accelerometer.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.AccelerometerDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.AccelerometerDataUpdatedEventArgs>, (object, global::Tizen.Sensor.AccelerometerDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.AccelerometerDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.AccelerometerDataUpdatedEventArgs>, global::Tizen.Sensor.AccelerometerDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.AccelerometerDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.AccelerometerDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6356,9 +6356,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.FaceDownGestureDetector.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.FaceDownGestureDetectorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.FaceDownGestureDetectorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.FaceDownGestureDetectorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.FaceDownGestureDetectorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.FaceDownGestureDetectorDataUpdatedEventArgs>, global::Tizen.Sensor.FaceDownGestureDetectorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.FaceDownGestureDetectorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.FaceDownGestureDetectorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6383,9 +6383,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.GravitySensor.AccuracyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, (object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.SensorAccuracyChangedEventArgs> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, global::Tizen.Sensor.SensorAccuracyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6393,9 +6393,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.GravitySensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.GravitySensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.GravitySensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.GravitySensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.GravitySensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.GravitySensorDataUpdatedEventArgs>, global::Tizen.Sensor.GravitySensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.GravitySensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.GravitySensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6420,9 +6420,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.Gyroscope.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.GyroscopeDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.GyroscopeDataUpdatedEventArgs>, (object, global::Tizen.Sensor.GyroscopeDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.GyroscopeDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.GyroscopeDataUpdatedEventArgs>, global::Tizen.Sensor.GyroscopeDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.GyroscopeDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.GyroscopeDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6447,9 +6447,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.GyroscopeRotationVectorSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.GyroscopeRotationVectorSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.GyroscopeRotationVectorSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.GyroscopeRotationVectorSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.GyroscopeRotationVectorSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.GyroscopeRotationVectorSensorDataUpdatedEventArgs>, global::Tizen.Sensor.GyroscopeRotationVectorSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.GyroscopeRotationVectorSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.GyroscopeRotationVectorSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6474,9 +6474,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.HeartRateMonitor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.HeartRateMonitorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.HeartRateMonitorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.HeartRateMonitorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.HeartRateMonitorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.HeartRateMonitorDataUpdatedEventArgs>, global::Tizen.Sensor.HeartRateMonitorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.HeartRateMonitorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.HeartRateMonitorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6501,9 +6501,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.HumiditySensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.HumiditySensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.HumiditySensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.HumiditySensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.HumiditySensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.HumiditySensorDataUpdatedEventArgs>, global::Tizen.Sensor.HumiditySensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.HumiditySensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.HumiditySensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6528,9 +6528,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.InVehicleActivityDetector.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.InVehicleActivityDetectorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.InVehicleActivityDetectorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.InVehicleActivityDetectorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.InVehicleActivityDetectorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.InVehicleActivityDetectorDataUpdatedEventArgs>, global::Tizen.Sensor.InVehicleActivityDetectorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.InVehicleActivityDetectorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.InVehicleActivityDetectorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6555,9 +6555,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.LightSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.LightSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.LightSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.LightSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.LightSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.LightSensorDataUpdatedEventArgs>, global::Tizen.Sensor.LightSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.LightSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.LightSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6582,9 +6582,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.LinearAccelerationSensor.AccuracyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, (object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.SensorAccuracyChangedEventArgs> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, global::Tizen.Sensor.SensorAccuracyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6592,9 +6592,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.LinearAccelerationSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.LinearAccelerationSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.LinearAccelerationSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.LinearAccelerationSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.LinearAccelerationSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.LinearAccelerationSensorDataUpdatedEventArgs>, global::Tizen.Sensor.LinearAccelerationSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.LinearAccelerationSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.LinearAccelerationSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6619,9 +6619,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.Magnetometer.AccuracyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, (object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.SensorAccuracyChangedEventArgs> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, global::Tizen.Sensor.SensorAccuracyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6629,9 +6629,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.Magnetometer.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.MagnetometerDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.MagnetometerDataUpdatedEventArgs>, (object, global::Tizen.Sensor.MagnetometerDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.MagnetometerDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.MagnetometerDataUpdatedEventArgs>, global::Tizen.Sensor.MagnetometerDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.MagnetometerDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.MagnetometerDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6656,9 +6656,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.MagnetometerRotationVectorSensor.AccuracyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, (object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.SensorAccuracyChangedEventArgs> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, global::Tizen.Sensor.SensorAccuracyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6666,9 +6666,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.MagnetometerRotationVectorSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.MagnetometerRotationVectorSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.MagnetometerRotationVectorSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.MagnetometerRotationVectorSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.MagnetometerRotationVectorSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.MagnetometerRotationVectorSensorDataUpdatedEventArgs>, global::Tizen.Sensor.MagnetometerRotationVectorSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.MagnetometerRotationVectorSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.MagnetometerRotationVectorSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6693,9 +6693,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.OrientationSensor.AccuracyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, (object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.SensorAccuracyChangedEventArgs> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, global::Tizen.Sensor.SensorAccuracyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6703,9 +6703,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.OrientationSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.OrientationSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.OrientationSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.OrientationSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.OrientationSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.OrientationSensorDataUpdatedEventArgs>, global::Tizen.Sensor.OrientationSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.OrientationSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.OrientationSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6730,9 +6730,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.Pedometer.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.PedometerDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.PedometerDataUpdatedEventArgs>, (object, global::Tizen.Sensor.PedometerDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.PedometerDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.PedometerDataUpdatedEventArgs>, global::Tizen.Sensor.PedometerDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.PedometerDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.PedometerDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6757,9 +6757,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.PickUpGestureDetector.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.PickUpGestureDetectorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.PickUpGestureDetectorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.PickUpGestureDetectorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.PickUpGestureDetectorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.PickUpGestureDetectorDataUpdatedEventArgs>, global::Tizen.Sensor.PickUpGestureDetectorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.PickUpGestureDetectorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.PickUpGestureDetectorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6784,9 +6784,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.PressureSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.PressureSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.PressureSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.PressureSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.PressureSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.PressureSensorDataUpdatedEventArgs>, global::Tizen.Sensor.PressureSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.PressureSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.PressureSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6811,9 +6811,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.ProximitySensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.ProximitySensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.ProximitySensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.ProximitySensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.ProximitySensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.ProximitySensorDataUpdatedEventArgs>, global::Tizen.Sensor.ProximitySensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.ProximitySensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.ProximitySensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6838,9 +6838,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.RotationVectorSensor.AccuracyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, (object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.SensorAccuracyChangedEventArgs> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, global::Tizen.Sensor.SensorAccuracyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6848,9 +6848,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.RotationVectorSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.RotationVectorSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.RotationVectorSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.RotationVectorSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.RotationVectorSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.RotationVectorSensorDataUpdatedEventArgs>, global::Tizen.Sensor.RotationVectorSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.RotationVectorSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.RotationVectorSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6875,9 +6875,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.RunningActivityDetector.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.RunningActivityDetectorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.RunningActivityDetectorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.RunningActivityDetectorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.RunningActivityDetectorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.RunningActivityDetectorDataUpdatedEventArgs>, global::Tizen.Sensor.RunningActivityDetectorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.RunningActivityDetectorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.RunningActivityDetectorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6902,9 +6902,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.SleepMonitor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.SleepMonitorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SleepMonitorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.SleepMonitorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.SleepMonitorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SleepMonitorDataUpdatedEventArgs>, global::Tizen.Sensor.SleepMonitorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.SleepMonitorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.SleepMonitorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6929,9 +6929,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.StationaryActivityDetector.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.StationaryActivityDetectorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.StationaryActivityDetectorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.StationaryActivityDetectorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.StationaryActivityDetectorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.StationaryActivityDetectorDataUpdatedEventArgs>, global::Tizen.Sensor.StationaryActivityDetectorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.StationaryActivityDetectorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.StationaryActivityDetectorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6956,9 +6956,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.TemperatureSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.TemperatureSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.TemperatureSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.TemperatureSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.TemperatureSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.TemperatureSensorDataUpdatedEventArgs>, global::Tizen.Sensor.TemperatureSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.TemperatureSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.TemperatureSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -6983,9 +6983,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.UltravioletSensor.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.UltravioletSensorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.UltravioletSensorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.UltravioletSensorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.UltravioletSensorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.UltravioletSensorDataUpdatedEventArgs>, global::Tizen.Sensor.UltravioletSensorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.UltravioletSensorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.UltravioletSensorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7010,9 +7010,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.UncalibratedGyroscope.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.UncalibratedGyroscopeDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.UncalibratedGyroscopeDataUpdatedEventArgs>, (object, global::Tizen.Sensor.UncalibratedGyroscopeDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.UncalibratedGyroscopeDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.UncalibratedGyroscopeDataUpdatedEventArgs>, global::Tizen.Sensor.UncalibratedGyroscopeDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.UncalibratedGyroscopeDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.UncalibratedGyroscopeDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7037,9 +7037,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.UncalibratedMagnetometer.AccuracyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, (object, global::Tizen.Sensor.SensorAccuracyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.SensorAccuracyChangedEventArgs> AccuracyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.SensorAccuracyChangedEventArgs>, global::Tizen.Sensor.SensorAccuracyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.SensorAccuracyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7047,9 +7047,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.UncalibratedMagnetometer.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.UncalibratedMagnetometerDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.UncalibratedMagnetometerDataUpdatedEventArgs>, (object, global::Tizen.Sensor.UncalibratedMagnetometerDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.UncalibratedMagnetometerDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.UncalibratedMagnetometerDataUpdatedEventArgs>, global::Tizen.Sensor.UncalibratedMagnetometerDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.UncalibratedMagnetometerDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.UncalibratedMagnetometerDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7074,9 +7074,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.WalkingActivityDetector.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.WalkingActivityDetectorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.WalkingActivityDetectorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.WalkingActivityDetectorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.WalkingActivityDetectorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.WalkingActivityDetectorDataUpdatedEventArgs>, global::Tizen.Sensor.WalkingActivityDetectorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.WalkingActivityDetectorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.WalkingActivityDetectorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7101,9 +7101,9 @@ namespace Tizen.Sensor
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Sensor.WristUpGestureDetector.DataUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Sensor.WristUpGestureDetectorDataUpdatedEventArgs)> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.WristUpGestureDetectorDataUpdatedEventArgs>, (object, global::Tizen.Sensor.WristUpGestureDetectorDataUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Sensor.WristUpGestureDetectorDataUpdatedEventArgs> DataUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Sensor.WristUpGestureDetectorDataUpdatedEventArgs>, global::Tizen.Sensor.WristUpGestureDetectorDataUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Sensor.WristUpGestureDetectorDataUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Sensor.WristUpGestureDetectorDataUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7142,9 +7142,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.Storage.StorageStateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> StorageStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> StorageStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7183,9 +7183,9 @@ namespace Tizen.System.Usb
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.Usb.UsbManager.DeviceHotPlugged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.System.Usb.HotPluggedEventArgs)> DeviceHotPlugged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.Usb.HotPluggedEventArgs>, (object, global::Tizen.System.Usb.HotPluggedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.System.Usb.HotPluggedEventArgs> DeviceHotPlugged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.Usb.HotPluggedEventArgs>, global::Tizen.System.Usb.HotPluggedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.Usb.HotPluggedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.Usb.HotPluggedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7224,9 +7224,9 @@ namespace Tizen.Telephony
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Telephony.SlotHandle.ChangeNotification"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Telephony.ChangeNotificationEventArgs)> ChangeNotification => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Telephony.ChangeNotificationEventArgs>, (object, global::Tizen.Telephony.ChangeNotificationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Telephony.ChangeNotificationEventArgs> ChangeNotification => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Telephony.ChangeNotificationEventArgs>, global::Tizen.Telephony.ChangeNotificationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Telephony.ChangeNotificationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Telephony.ChangeNotificationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7265,9 +7265,9 @@ namespace Tizen.Uix.Stt
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Stt.SttClient.DefaultLanguageChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Stt.DefaultLanguageChangedEventArgs)> DefaultLanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.DefaultLanguageChangedEventArgs>, (object, global::Tizen.Uix.Stt.DefaultLanguageChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Stt.DefaultLanguageChangedEventArgs> DefaultLanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.DefaultLanguageChangedEventArgs>, global::Tizen.Uix.Stt.DefaultLanguageChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Stt.DefaultLanguageChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Stt.DefaultLanguageChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7275,9 +7275,9 @@ namespace Tizen.Uix.Stt
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Stt.SttClient.EngineChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Stt.EngineChangedEventArgs)> EngineChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.EngineChangedEventArgs>, (object, global::Tizen.Uix.Stt.EngineChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Stt.EngineChangedEventArgs> EngineChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.EngineChangedEventArgs>, global::Tizen.Uix.Stt.EngineChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Stt.EngineChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Stt.EngineChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7285,9 +7285,9 @@ namespace Tizen.Uix.Stt
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Stt.SttClient.ErrorOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Stt.ErrorOccurredEventArgs)> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.ErrorOccurredEventArgs>, (object, global::Tizen.Uix.Stt.ErrorOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Stt.ErrorOccurredEventArgs> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.ErrorOccurredEventArgs>, global::Tizen.Uix.Stt.ErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Stt.ErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Stt.ErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7295,9 +7295,9 @@ namespace Tizen.Uix.Stt
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Stt.SttClient.RecognitionResult"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Stt.RecognitionResultEventArgs)> RecognitionResult => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.RecognitionResultEventArgs>, (object, global::Tizen.Uix.Stt.RecognitionResultEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Stt.RecognitionResultEventArgs> RecognitionResult => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.RecognitionResultEventArgs>, global::Tizen.Uix.Stt.RecognitionResultEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Stt.RecognitionResultEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Stt.RecognitionResultEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7305,9 +7305,9 @@ namespace Tizen.Uix.Stt
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Stt.SttClient.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Stt.StateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.StateChangedEventArgs>, (object, global::Tizen.Uix.Stt.StateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Stt.StateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Stt.StateChangedEventArgs>, global::Tizen.Uix.Stt.StateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Stt.StateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Stt.StateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7346,9 +7346,9 @@ namespace Tizen.Uix.Tts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Tts.TtsClient.DefaultVoiceChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Tts.DefaultVoiceChangedEventArgs)> DefaultVoiceChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.DefaultVoiceChangedEventArgs>, (object, global::Tizen.Uix.Tts.DefaultVoiceChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Tts.DefaultVoiceChangedEventArgs> DefaultVoiceChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.DefaultVoiceChangedEventArgs>, global::Tizen.Uix.Tts.DefaultVoiceChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Tts.DefaultVoiceChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Tts.DefaultVoiceChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7356,9 +7356,9 @@ namespace Tizen.Uix.Tts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Tts.TtsClient.EngineChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Tts.EngineChangedEventArgs)> EngineChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.EngineChangedEventArgs>, (object, global::Tizen.Uix.Tts.EngineChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Tts.EngineChangedEventArgs> EngineChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.EngineChangedEventArgs>, global::Tizen.Uix.Tts.EngineChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Tts.EngineChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Tts.EngineChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7366,9 +7366,9 @@ namespace Tizen.Uix.Tts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Tts.TtsClient.ErrorOccurred"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Tts.ErrorOccurredEventArgs)> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.ErrorOccurredEventArgs>, (object, global::Tizen.Uix.Tts.ErrorOccurredEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Tts.ErrorOccurredEventArgs> ErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.ErrorOccurredEventArgs>, global::Tizen.Uix.Tts.ErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Tts.ErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Tts.ErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7376,9 +7376,9 @@ namespace Tizen.Uix.Tts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Tts.TtsClient.StateChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Tts.StateChangedEventArgs)> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.StateChangedEventArgs>, (object, global::Tizen.Uix.Tts.StateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Tts.StateChangedEventArgs> StateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.StateChangedEventArgs>, global::Tizen.Uix.Tts.StateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Tts.StateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Tts.StateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7386,9 +7386,9 @@ namespace Tizen.Uix.Tts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Tts.TtsClient.UtteranceCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Tts.UtteranceEventArgs)> UtteranceCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.UtteranceEventArgs>, (object, global::Tizen.Uix.Tts.UtteranceEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Tts.UtteranceEventArgs> UtteranceCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.UtteranceEventArgs>, global::Tizen.Uix.Tts.UtteranceEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Tts.UtteranceEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Tts.UtteranceEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7396,9 +7396,9 @@ namespace Tizen.Uix.Tts
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.Tts.TtsClient.UtteranceStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.Uix.Tts.UtteranceEventArgs)> UtteranceStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.UtteranceEventArgs>, (object, global::Tizen.Uix.Tts.UtteranceEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.Uix.Tts.UtteranceEventArgs> UtteranceStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.Tts.UtteranceEventArgs>, global::Tizen.Uix.Tts.UtteranceEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.Tts.UtteranceEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.Tts.UtteranceEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7437,9 +7437,9 @@ namespace Tizen.WebView
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.WebView.WebView.LoadError"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.WebView.SmartCallbackLoadErrorArgs)> LoadError => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.WebView.SmartCallbackLoadErrorArgs>, (object, global::Tizen.WebView.SmartCallbackLoadErrorArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.WebView.SmartCallbackLoadErrorArgs> LoadError => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.WebView.SmartCallbackLoadErrorArgs>, global::Tizen.WebView.SmartCallbackLoadErrorArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.WebView.SmartCallbackLoadErrorArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.WebView.SmartCallbackLoadErrorArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7447,9 +7447,9 @@ namespace Tizen.WebView
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.WebView.WebView.LoadFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LoadFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LoadFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7457,9 +7457,9 @@ namespace Tizen.WebView
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.WebView.WebView.LoadStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LoadStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LoadStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7467,9 +7467,9 @@ namespace Tizen.WebView
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.WebView.WebView.TitleChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.WebView.SmartCallbackArgs)> TitleChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.WebView.SmartCallbackArgs>, (object, global::Tizen.WebView.SmartCallbackArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.WebView.SmartCallbackArgs> TitleChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.WebView.SmartCallbackArgs>, global::Tizen.WebView.SmartCallbackArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.WebView.SmartCallbackArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.WebView.SmartCallbackArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7477,9 +7477,9 @@ namespace Tizen.WebView
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.WebView.WebView.UrlChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Tizen.WebView.SmartCallbackArgs)> UrlChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.WebView.SmartCallbackArgs>, (object, global::Tizen.WebView.SmartCallbackArgs)>(eventHandler =>
+        public global::System.IObservable<global::Tizen.WebView.SmartCallbackArgs> UrlChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.WebView.SmartCallbackArgs>, global::Tizen.WebView.SmartCallbackArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.WebView.SmartCallbackArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.WebView.SmartCallbackArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7517,9 +7517,9 @@ namespace Tizen.Account.AccountManager
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Account.AccountManager.AccountService.AccountUpdated"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Account.AccountManager.AccountSubscriberEventArgs)> AccountServiceAccountUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Account.AccountManager.AccountSubscriberEventArgs>, (object, global::Tizen.Account.AccountManager.AccountSubscriberEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Account.AccountManager.AccountSubscriberEventArgs> AccountServiceAccountUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Account.AccountManager.AccountSubscriberEventArgs>, global::Tizen.Account.AccountManager.AccountSubscriberEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Account.AccountManager.AccountSubscriberEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Account.AccountManager.AccountSubscriberEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7537,9 +7537,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.ApplicationManager.ApplicationDisabled"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.ApplicationDisabledEventArgs)> ApplicationManagerApplicationDisabled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.ApplicationDisabledEventArgs>, (object, global::Tizen.Applications.ApplicationDisabledEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.ApplicationDisabledEventArgs> ApplicationManagerApplicationDisabled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.ApplicationDisabledEventArgs>, global::Tizen.Applications.ApplicationDisabledEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.ApplicationDisabledEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.ApplicationDisabledEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7547,9 +7547,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.ApplicationManager.ApplicationEnabled"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.ApplicationEnabledEventArgs)> ApplicationManagerApplicationEnabled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.ApplicationEnabledEventArgs>, (object, global::Tizen.Applications.ApplicationEnabledEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.ApplicationEnabledEventArgs> ApplicationManagerApplicationEnabled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.ApplicationEnabledEventArgs>, global::Tizen.Applications.ApplicationEnabledEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.ApplicationEnabledEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.ApplicationEnabledEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7557,9 +7557,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.ApplicationManager.ApplicationLaunched"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.ApplicationLaunchedEventArgs)> ApplicationManagerApplicationLaunched => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.ApplicationLaunchedEventArgs>, (object, global::Tizen.Applications.ApplicationLaunchedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.ApplicationLaunchedEventArgs> ApplicationManagerApplicationLaunched => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.ApplicationLaunchedEventArgs>, global::Tizen.Applications.ApplicationLaunchedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.ApplicationLaunchedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.ApplicationLaunchedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7567,9 +7567,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.ApplicationManager.ApplicationTerminated"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.ApplicationTerminatedEventArgs)> ApplicationManagerApplicationTerminated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.ApplicationTerminatedEventArgs>, (object, global::Tizen.Applications.ApplicationTerminatedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.ApplicationTerminatedEventArgs> ApplicationManagerApplicationTerminated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.ApplicationTerminatedEventArgs>, global::Tizen.Applications.ApplicationTerminatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.ApplicationTerminatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.ApplicationTerminatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7577,9 +7577,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.BadgeControl.Changed"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.BadgeEventArgs)> BadgeControlChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.BadgeEventArgs>, (object, global::Tizen.Applications.BadgeEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.BadgeEventArgs> BadgeControlChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.BadgeEventArgs>, global::Tizen.Applications.BadgeEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.BadgeEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.BadgeEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7587,9 +7587,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.PackageManager.ClearDataProgressChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.PackageManagerEventArgs)> PackageManagerClearDataProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, (object, global::Tizen.Applications.PackageManagerEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.PackageManagerEventArgs> PackageManagerClearDataProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, global::Tizen.Applications.PackageManagerEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7597,9 +7597,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.PackageManager.InstallProgressChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.PackageManagerEventArgs)> PackageManagerInstallProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, (object, global::Tizen.Applications.PackageManagerEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.PackageManagerEventArgs> PackageManagerInstallProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, global::Tizen.Applications.PackageManagerEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7607,9 +7607,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.PackageManager.MoveProgressChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.PackageManagerEventArgs)> PackageManagerMoveProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, (object, global::Tizen.Applications.PackageManagerEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.PackageManagerEventArgs> PackageManagerMoveProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, global::Tizen.Applications.PackageManagerEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7617,9 +7617,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.PackageManager.UninstallProgressChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.PackageManagerEventArgs)> PackageManagerUninstallProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, (object, global::Tizen.Applications.PackageManagerEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.PackageManagerEventArgs> PackageManagerUninstallProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, global::Tizen.Applications.PackageManagerEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7627,9 +7627,9 @@ namespace Tizen.Applications
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.PackageManager.UpdateProgressChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.PackageManagerEventArgs)> PackageManagerUpdateProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, (object, global::Tizen.Applications.PackageManagerEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.PackageManagerEventArgs> PackageManagerUpdateProgressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.PackageManagerEventArgs>, global::Tizen.Applications.PackageManagerEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.PackageManagerEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7647,9 +7647,9 @@ namespace Tizen.Applications.NotificationEventListener
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.NotificationEventListener.NotificationListenerManager.Added"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs)> NotificationListenerManagerAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.NotificationEventListener.NotificationEventArgs>, (object, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.NotificationEventListener.NotificationEventArgs> NotificationListenerManagerAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.NotificationEventListener.NotificationEventArgs>, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7657,9 +7657,9 @@ namespace Tizen.Applications.NotificationEventListener
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.NotificationEventListener.NotificationListenerManager.Deleted"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.NotificationEventListener.NotificationDeleteEventArgs)> NotificationListenerManagerDeleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.NotificationEventListener.NotificationDeleteEventArgs>, (object, global::Tizen.Applications.NotificationEventListener.NotificationDeleteEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.NotificationEventListener.NotificationDeleteEventArgs> NotificationListenerManagerDeleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.NotificationEventListener.NotificationDeleteEventArgs>, global::Tizen.Applications.NotificationEventListener.NotificationDeleteEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.NotificationEventListener.NotificationDeleteEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.NotificationEventListener.NotificationDeleteEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7667,9 +7667,9 @@ namespace Tizen.Applications.NotificationEventListener
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Applications.NotificationEventListener.NotificationListenerManager.Updated"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs)> NotificationListenerManagerUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.NotificationEventListener.NotificationEventArgs>, (object, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Applications.NotificationEventListener.NotificationEventArgs> NotificationListenerManagerUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Applications.NotificationEventListener.NotificationEventArgs>, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Applications.NotificationEventListener.NotificationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7687,9 +7687,9 @@ namespace Tizen.Content.MediaContent
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Content.MediaContent.MediaDatabase.FolderUpdated"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Content.MediaContent.FolderUpdatedEventArgs)> MediaDatabaseFolderUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Content.MediaContent.FolderUpdatedEventArgs>, (object, global::Tizen.Content.MediaContent.FolderUpdatedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Content.MediaContent.FolderUpdatedEventArgs> MediaDatabaseFolderUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Content.MediaContent.FolderUpdatedEventArgs>, global::Tizen.Content.MediaContent.FolderUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Content.MediaContent.FolderUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Content.MediaContent.FolderUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7697,9 +7697,9 @@ namespace Tizen.Content.MediaContent
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Content.MediaContent.MediaDatabase.MediaInfoUpdated"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Content.MediaContent.MediaInfoUpdatedEventArgs)> MediaDatabaseMediaInfoUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Content.MediaContent.MediaInfoUpdatedEventArgs>, (object, global::Tizen.Content.MediaContent.MediaInfoUpdatedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Content.MediaContent.MediaInfoUpdatedEventArgs> MediaDatabaseMediaInfoUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Content.MediaContent.MediaInfoUpdatedEventArgs>, global::Tizen.Content.MediaContent.MediaInfoUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Content.MediaContent.MediaInfoUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Content.MediaContent.MediaInfoUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7717,9 +7717,9 @@ namespace Tizen.Messaging.Messages
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Messaging.Messages.MessagesManager.MessageReceived"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Messaging.Messages.MessageReceivedEventArgs)> MessagesManagerMessageReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Messaging.Messages.MessageReceivedEventArgs>, (object, global::Tizen.Messaging.Messages.MessageReceivedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Messaging.Messages.MessageReceivedEventArgs> MessagesManagerMessageReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Messaging.Messages.MessageReceivedEventArgs>, global::Tizen.Messaging.Messages.MessageReceivedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Messaging.Messages.MessageReceivedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Messaging.Messages.MessageReceivedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7737,9 +7737,9 @@ namespace Tizen.Messaging.Push
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Messaging.Push.PushClient.NotificationReceived"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Messaging.Push.PushMessageEventArgs)> PushClientNotificationReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Messaging.Push.PushMessageEventArgs>, (object, global::Tizen.Messaging.Push.PushMessageEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Messaging.Push.PushMessageEventArgs> PushClientNotificationReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Messaging.Push.PushMessageEventArgs>, global::Tizen.Messaging.Push.PushMessageEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Messaging.Push.PushMessageEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Messaging.Push.PushMessageEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7747,9 +7747,9 @@ namespace Tizen.Messaging.Push
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Messaging.Push.PushClient.StateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Messaging.Push.PushConnectionStateEventArgs)> PushClientStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Messaging.Push.PushConnectionStateEventArgs>, (object, global::Tizen.Messaging.Push.PushConnectionStateEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Messaging.Push.PushConnectionStateEventArgs> PushClientStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Messaging.Push.PushConnectionStateEventArgs>, global::Tizen.Messaging.Push.PushConnectionStateEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Messaging.Push.PushConnectionStateEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Messaging.Push.PushConnectionStateEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7767,9 +7767,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AudioManager.DeviceConnectionChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Multimedia.AudioDeviceConnectionChangedEventArgs)> AudioManagerDeviceConnectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioDeviceConnectionChangedEventArgs>, (object, global::Tizen.Multimedia.AudioDeviceConnectionChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Multimedia.AudioDeviceConnectionChangedEventArgs> AudioManagerDeviceConnectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioDeviceConnectionChangedEventArgs>, global::Tizen.Multimedia.AudioDeviceConnectionChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.AudioDeviceConnectionChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.AudioDeviceConnectionChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7777,9 +7777,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AudioManager.DeviceStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Multimedia.AudioDeviceStateChangedEventArgs)> AudioManagerDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioDeviceStateChangedEventArgs>, (object, global::Tizen.Multimedia.AudioDeviceStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Multimedia.AudioDeviceStateChangedEventArgs> AudioManagerDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.AudioDeviceStateChangedEventArgs>, global::Tizen.Multimedia.AudioDeviceStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.AudioDeviceStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.AudioDeviceStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7787,9 +7787,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.AudioStreamPolicy.StreamFocusStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Multimedia.StreamFocusStateChangedEventArgs)> AudioStreamPolicyStreamFocusStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.StreamFocusStateChangedEventArgs>, (object, global::Tizen.Multimedia.StreamFocusStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Multimedia.StreamFocusStateChangedEventArgs> AudioStreamPolicyStreamFocusStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.StreamFocusStateChangedEventArgs>, global::Tizen.Multimedia.StreamFocusStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.StreamFocusStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.StreamFocusStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7797,9 +7797,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Camera.DeviceStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Multimedia.CameraDeviceStateChangedEventArgs)> CameraDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraDeviceStateChangedEventArgs>, (object, global::Tizen.Multimedia.CameraDeviceStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Multimedia.CameraDeviceStateChangedEventArgs> CameraDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.CameraDeviceStateChangedEventArgs>, global::Tizen.Multimedia.CameraDeviceStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.CameraDeviceStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.CameraDeviceStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7807,9 +7807,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Recorder.DeviceStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Multimedia.RecorderDeviceStateChangedEventArgs)> RecorderDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecorderDeviceStateChangedEventArgs>, (object, global::Tizen.Multimedia.RecorderDeviceStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Multimedia.RecorderDeviceStateChangedEventArgs> RecorderDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.RecorderDeviceStateChangedEventArgs>, global::Tizen.Multimedia.RecorderDeviceStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.RecorderDeviceStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.RecorderDeviceStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7827,9 +7827,9 @@ namespace Tizen.Multimedia.Remoting
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Multimedia.Remoting.MediaControlServer.PlaybackCommandReceived"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Multimedia.Remoting.PlaybackCommandReceivedEventArgs)> MediaControlServerPlaybackCommandReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.PlaybackCommandReceivedEventArgs>, (object, global::Tizen.Multimedia.Remoting.PlaybackCommandReceivedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Multimedia.Remoting.PlaybackCommandReceivedEventArgs> MediaControlServerPlaybackCommandReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Multimedia.Remoting.PlaybackCommandReceivedEventArgs>, global::Tizen.Multimedia.Remoting.PlaybackCommandReceivedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Multimedia.Remoting.PlaybackCommandReceivedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Multimedia.Remoting.PlaybackCommandReceivedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7847,9 +7847,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAdapter.DiscoveryStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Bluetooth.DiscoveryStateChangedEventArgs)> BluetoothAdapterDiscoveryStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.DiscoveryStateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.DiscoveryStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Bluetooth.DiscoveryStateChangedEventArgs> BluetoothAdapterDiscoveryStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.DiscoveryStateChangedEventArgs>, global::Tizen.Network.Bluetooth.DiscoveryStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.DiscoveryStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.DiscoveryStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7857,9 +7857,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAdapter.NameChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Bluetooth.NameChangedEventArgs)> BluetoothAdapterNameChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.NameChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.NameChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Bluetooth.NameChangedEventArgs> BluetoothAdapterNameChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.NameChangedEventArgs>, global::Tizen.Network.Bluetooth.NameChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.NameChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.NameChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7867,9 +7867,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAdapter.ScanResultChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Bluetooth.AdapterLeScanResultChangedEventArgs)> BluetoothAdapterScanResultChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AdapterLeScanResultChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.AdapterLeScanResultChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Bluetooth.AdapterLeScanResultChangedEventArgs> BluetoothAdapterScanResultChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.AdapterLeScanResultChangedEventArgs>, global::Tizen.Network.Bluetooth.AdapterLeScanResultChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.AdapterLeScanResultChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.AdapterLeScanResultChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7877,9 +7877,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAdapter.StateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Bluetooth.StateChangedEventArgs)> BluetoothAdapterStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.StateChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.StateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Bluetooth.StateChangedEventArgs> BluetoothAdapterStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.StateChangedEventArgs>, global::Tizen.Network.Bluetooth.StateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.StateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.StateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7887,9 +7887,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAdapter.VisibilityDurationChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Bluetooth.VisibilityDurationChangedEventArgs)> BluetoothAdapterVisibilityDurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.VisibilityDurationChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.VisibilityDurationChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Bluetooth.VisibilityDurationChangedEventArgs> BluetoothAdapterVisibilityDurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.VisibilityDurationChangedEventArgs>, global::Tizen.Network.Bluetooth.VisibilityDurationChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.VisibilityDurationChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.VisibilityDurationChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7897,9 +7897,9 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Bluetooth.BluetoothAdapter.VisibilityModeChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Bluetooth.VisibilityModeChangedEventArgs)> BluetoothAdapterVisibilityModeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.VisibilityModeChangedEventArgs>, (object, global::Tizen.Network.Bluetooth.VisibilityModeChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Bluetooth.VisibilityModeChangedEventArgs> BluetoothAdapterVisibilityModeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Bluetooth.VisibilityModeChangedEventArgs>, global::Tizen.Network.Bluetooth.VisibilityModeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Bluetooth.VisibilityModeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Bluetooth.VisibilityModeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7917,9 +7917,9 @@ namespace Tizen.Network.Connection
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Connection.ConnectionManager.ConnectionTypeChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Connection.ConnectionTypeEventArgs)> ConnectionManagerConnectionTypeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.ConnectionTypeEventArgs>, (object, global::Tizen.Network.Connection.ConnectionTypeEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Connection.ConnectionTypeEventArgs> ConnectionManagerConnectionTypeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.ConnectionTypeEventArgs>, global::Tizen.Network.Connection.ConnectionTypeEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Connection.ConnectionTypeEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Connection.ConnectionTypeEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7927,9 +7927,9 @@ namespace Tizen.Network.Connection
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Connection.ConnectionManager.EthernetCableStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Connection.EthernetCableStateEventArgs)> ConnectionManagerEthernetCableStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.EthernetCableStateEventArgs>, (object, global::Tizen.Network.Connection.EthernetCableStateEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Connection.EthernetCableStateEventArgs> ConnectionManagerEthernetCableStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.EthernetCableStateEventArgs>, global::Tizen.Network.Connection.EthernetCableStateEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Connection.EthernetCableStateEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Connection.EthernetCableStateEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7937,9 +7937,9 @@ namespace Tizen.Network.Connection
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Connection.ConnectionManager.IPAddressChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Connection.AddressEventArgs)> ConnectionManagerIPAddressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.AddressEventArgs>, (object, global::Tizen.Network.Connection.AddressEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Connection.AddressEventArgs> ConnectionManagerIPAddressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.AddressEventArgs>, global::Tizen.Network.Connection.AddressEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Connection.AddressEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Connection.AddressEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7947,9 +7947,9 @@ namespace Tizen.Network.Connection
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Connection.ConnectionManager.ProxyAddressChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Connection.AddressEventArgs)> ConnectionManagerProxyAddressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.AddressEventArgs>, (object, global::Tizen.Network.Connection.AddressEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Connection.AddressEventArgs> ConnectionManagerProxyAddressChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Connection.AddressEventArgs>, global::Tizen.Network.Connection.AddressEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Connection.AddressEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Connection.AddressEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7967,9 +7967,9 @@ namespace Tizen.Network.IoTConnectivity
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.IoTConnectivity.IoTConnectivityClientManager.DeviceInformationFound"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.IoTConnectivity.DeviceInformationFoundEventArgs)> IoTConnectivityClientManagerDeviceInformationFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.DeviceInformationFoundEventArgs>, (object, global::Tizen.Network.IoTConnectivity.DeviceInformationFoundEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.IoTConnectivity.DeviceInformationFoundEventArgs> IoTConnectivityClientManagerDeviceInformationFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.DeviceInformationFoundEventArgs>, global::Tizen.Network.IoTConnectivity.DeviceInformationFoundEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.IoTConnectivity.DeviceInformationFoundEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.IoTConnectivity.DeviceInformationFoundEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7977,9 +7977,9 @@ namespace Tizen.Network.IoTConnectivity
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.IoTConnectivity.IoTConnectivityClientManager.FindingErrorOccurred"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.IoTConnectivity.FindingErrorOccurredEventArgs)> IoTConnectivityClientManagerFindingErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.FindingErrorOccurredEventArgs>, (object, global::Tizen.Network.IoTConnectivity.FindingErrorOccurredEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.IoTConnectivity.FindingErrorOccurredEventArgs> IoTConnectivityClientManagerFindingErrorOccurred => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.FindingErrorOccurredEventArgs>, global::Tizen.Network.IoTConnectivity.FindingErrorOccurredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.IoTConnectivity.FindingErrorOccurredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.IoTConnectivity.FindingErrorOccurredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7987,9 +7987,9 @@ namespace Tizen.Network.IoTConnectivity
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.IoTConnectivity.IoTConnectivityClientManager.PlatformInformationFound"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.IoTConnectivity.PlatformInformationFoundEventArgs)> IoTConnectivityClientManagerPlatformInformationFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.PlatformInformationFoundEventArgs>, (object, global::Tizen.Network.IoTConnectivity.PlatformInformationFoundEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.IoTConnectivity.PlatformInformationFoundEventArgs> IoTConnectivityClientManagerPlatformInformationFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.PlatformInformationFoundEventArgs>, global::Tizen.Network.IoTConnectivity.PlatformInformationFoundEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.IoTConnectivity.PlatformInformationFoundEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.IoTConnectivity.PlatformInformationFoundEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -7997,9 +7997,9 @@ namespace Tizen.Network.IoTConnectivity
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.IoTConnectivity.IoTConnectivityClientManager.PresenceReceived"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.IoTConnectivity.PresenceReceivedEventArgs)> IoTConnectivityClientManagerPresenceReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.PresenceReceivedEventArgs>, (object, global::Tizen.Network.IoTConnectivity.PresenceReceivedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.IoTConnectivity.PresenceReceivedEventArgs> IoTConnectivityClientManagerPresenceReceived => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.PresenceReceivedEventArgs>, global::Tizen.Network.IoTConnectivity.PresenceReceivedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.IoTConnectivity.PresenceReceivedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.IoTConnectivity.PresenceReceivedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8007,9 +8007,9 @@ namespace Tizen.Network.IoTConnectivity
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.IoTConnectivity.IoTConnectivityClientManager.ResourceFound"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.IoTConnectivity.ResourceFoundEventArgs)> IoTConnectivityClientManagerResourceFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.ResourceFoundEventArgs>, (object, global::Tizen.Network.IoTConnectivity.ResourceFoundEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.IoTConnectivity.ResourceFoundEventArgs> IoTConnectivityClientManagerResourceFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.IoTConnectivity.ResourceFoundEventArgs>, global::Tizen.Network.IoTConnectivity.ResourceFoundEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.IoTConnectivity.ResourceFoundEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.IoTConnectivity.ResourceFoundEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8027,9 +8027,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcManager.ActivationChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Nfc.ActivationChangedEventArgs)> NfcManagerActivationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.ActivationChangedEventArgs>, (object, global::Tizen.Network.Nfc.ActivationChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Nfc.ActivationChangedEventArgs> NfcManagerActivationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.ActivationChangedEventArgs>, global::Tizen.Network.Nfc.ActivationChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.ActivationChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.ActivationChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8037,9 +8037,9 @@ namespace Tizen.Network.Nfc
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.Nfc.NfcManager.NdefMessageDiscovered"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.Nfc.NdefMessageDiscoveredEventArgs)> NfcManagerNdefMessageDiscovered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.NdefMessageDiscoveredEventArgs>, (object, global::Tizen.Network.Nfc.NdefMessageDiscoveredEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.Nfc.NdefMessageDiscoveredEventArgs> NfcManagerNdefMessageDiscovered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.Nfc.NdefMessageDiscoveredEventArgs>, global::Tizen.Network.Nfc.NdefMessageDiscoveredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.Nfc.NdefMessageDiscoveredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.Nfc.NdefMessageDiscoveredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8057,9 +8057,9 @@ namespace Tizen.Network.WiFi
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFi.WiFiManager.BackgroundScanFinished"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::System.EventArgs)> WiFiManagerBackgroundScanFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::System.EventArgs> WiFiManagerBackgroundScanFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8067,9 +8067,9 @@ namespace Tizen.Network.WiFi
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFi.WiFiManager.ConnectionStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.WiFi.ConnectionStateChangedEventArgs)> WiFiManagerConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFi.ConnectionStateChangedEventArgs>, (object, global::Tizen.Network.WiFi.ConnectionStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.WiFi.ConnectionStateChangedEventArgs> WiFiManagerConnectionStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFi.ConnectionStateChangedEventArgs>, global::Tizen.Network.WiFi.ConnectionStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFi.ConnectionStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFi.ConnectionStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8077,9 +8077,9 @@ namespace Tizen.Network.WiFi
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFi.WiFiManager.DeviceStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.WiFi.DeviceStateChangedEventArgs)> WiFiManagerDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFi.DeviceStateChangedEventArgs>, (object, global::Tizen.Network.WiFi.DeviceStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.WiFi.DeviceStateChangedEventArgs> WiFiManagerDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFi.DeviceStateChangedEventArgs>, global::Tizen.Network.WiFi.DeviceStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFi.DeviceStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFi.DeviceStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8087,9 +8087,9 @@ namespace Tizen.Network.WiFi
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFi.WiFiManager.RssiLevelChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.WiFi.RssiLevelChangedEventArgs)> WiFiManagerRssiLevelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFi.RssiLevelChangedEventArgs>, (object, global::Tizen.Network.WiFi.RssiLevelChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.WiFi.RssiLevelChangedEventArgs> WiFiManagerRssiLevelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFi.RssiLevelChangedEventArgs>, global::Tizen.Network.WiFi.RssiLevelChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFi.RssiLevelChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFi.RssiLevelChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8107,9 +8107,9 @@ namespace Tizen.Network.WiFiDirect
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFiDirect.WiFiDirectManager.ConnectionStatusChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.WiFiDirect.ConnectionStatusChangedEventArgs)> WiFiDirectManagerConnectionStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.ConnectionStatusChangedEventArgs>, (object, global::Tizen.Network.WiFiDirect.ConnectionStatusChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.WiFiDirect.ConnectionStatusChangedEventArgs> WiFiDirectManagerConnectionStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.ConnectionStatusChangedEventArgs>, global::Tizen.Network.WiFiDirect.ConnectionStatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFiDirect.ConnectionStatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFiDirect.ConnectionStatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8117,9 +8117,9 @@ namespace Tizen.Network.WiFiDirect
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFiDirect.WiFiDirectManager.DeviceStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.WiFiDirect.DeviceStateChangedEventArgs)> WiFiDirectManagerDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.DeviceStateChangedEventArgs>, (object, global::Tizen.Network.WiFiDirect.DeviceStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.WiFiDirect.DeviceStateChangedEventArgs> WiFiDirectManagerDeviceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.DeviceStateChangedEventArgs>, global::Tizen.Network.WiFiDirect.DeviceStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFiDirect.DeviceStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFiDirect.DeviceStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8127,9 +8127,9 @@ namespace Tizen.Network.WiFiDirect
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFiDirect.WiFiDirectManager.DiscoveryStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.WiFiDirect.DiscoveryStateChangedEventArgs)> WiFiDirectManagerDiscoveryStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.DiscoveryStateChangedEventArgs>, (object, global::Tizen.Network.WiFiDirect.DiscoveryStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.WiFiDirect.DiscoveryStateChangedEventArgs> WiFiDirectManagerDiscoveryStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.DiscoveryStateChangedEventArgs>, global::Tizen.Network.WiFiDirect.DiscoveryStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFiDirect.DiscoveryStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFiDirect.DiscoveryStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8137,9 +8137,9 @@ namespace Tizen.Network.WiFiDirect
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFiDirect.WiFiDirectManager.PeerFound"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.WiFiDirect.PeerFoundEventArgs)> WiFiDirectManagerPeerFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.PeerFoundEventArgs>, (object, global::Tizen.Network.WiFiDirect.PeerFoundEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.WiFiDirect.PeerFoundEventArgs> WiFiDirectManagerPeerFound => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.PeerFoundEventArgs>, global::Tizen.Network.WiFiDirect.PeerFoundEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFiDirect.PeerFoundEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFiDirect.PeerFoundEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8147,9 +8147,9 @@ namespace Tizen.Network.WiFiDirect
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Network.WiFiDirect.WiFiDirectManager.StateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Network.WiFiDirect.StateChangedEventArgs)> WiFiDirectManagerStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.StateChangedEventArgs>, (object, global::Tizen.Network.WiFiDirect.StateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Network.WiFiDirect.StateChangedEventArgs> WiFiDirectManagerStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Network.WiFiDirect.StateChangedEventArgs>, global::Tizen.Network.WiFiDirect.StateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Network.WiFiDirect.StateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Network.WiFiDirect.StateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8167,9 +8167,9 @@ namespace Tizen.Pims.Calendar
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Pims.Calendar.CalendarReminder.ReminderAlerted"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Pims.Calendar.ReminderAlertedEventArgs)> CalendarReminderReminderAlerted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Pims.Calendar.ReminderAlertedEventArgs>, (object, global::Tizen.Pims.Calendar.ReminderAlertedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Pims.Calendar.ReminderAlertedEventArgs> CalendarReminderReminderAlerted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Pims.Calendar.ReminderAlertedEventArgs>, global::Tizen.Pims.Calendar.ReminderAlertedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Pims.Calendar.ReminderAlertedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Pims.Calendar.ReminderAlertedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8187,9 +8187,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.Battery.ChargingStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.BatteryChargingStateChangedEventArgs)> BatteryChargingStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.BatteryChargingStateChangedEventArgs>, (object, global::Tizen.System.BatteryChargingStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.BatteryChargingStateChangedEventArgs> BatteryChargingStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.BatteryChargingStateChangedEventArgs>, global::Tizen.System.BatteryChargingStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.BatteryChargingStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.BatteryChargingStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8197,9 +8197,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.Battery.LevelChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.BatteryLevelChangedEventArgs)> BatteryLevelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.BatteryLevelChangedEventArgs>, (object, global::Tizen.System.BatteryLevelChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.BatteryLevelChangedEventArgs> BatteryLevelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.BatteryLevelChangedEventArgs>, global::Tizen.System.BatteryLevelChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.BatteryLevelChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.BatteryLevelChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8207,9 +8207,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.Battery.PercentChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.BatteryPercentChangedEventArgs)> BatteryPercentChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.BatteryPercentChangedEventArgs>, (object, global::Tizen.System.BatteryPercentChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.BatteryPercentChangedEventArgs> BatteryPercentChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.BatteryPercentChangedEventArgs>, global::Tizen.System.BatteryPercentChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.BatteryPercentChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.BatteryPercentChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8217,9 +8217,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.Display.StateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.DisplayStateChangedEventArgs)> DisplayStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.DisplayStateChangedEventArgs>, (object, global::Tizen.System.DisplayStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.DisplayStateChangedEventArgs> DisplayStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.DisplayStateChangedEventArgs>, global::Tizen.System.DisplayStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.DisplayStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.DisplayStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8227,9 +8227,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.Led.BrightnessChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.LedBrightnessChangedEventArgs)> LedBrightnessChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LedBrightnessChangedEventArgs>, (object, global::Tizen.System.LedBrightnessChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.LedBrightnessChangedEventArgs> LedBrightnessChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LedBrightnessChangedEventArgs>, global::Tizen.System.LedBrightnessChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.LedBrightnessChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.LedBrightnessChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8237,9 +8237,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.MediaKey.Event"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.MediaKeyEventArgs)> MediaKeyEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.MediaKeyEventArgs>, (object, global::Tizen.System.MediaKeyEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.MediaKeyEventArgs> MediaKeyEvent => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.MediaKeyEventArgs>, global::Tizen.System.MediaKeyEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.MediaKeyEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.MediaKeyEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8247,9 +8247,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.AccessibilityTtsSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.AccessibilityTtsSettingChangedEventArgs)> SystemSettingsAccessibilityTtsSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.AccessibilityTtsSettingChangedEventArgs>, (object, global::Tizen.System.AccessibilityTtsSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.AccessibilityTtsSettingChangedEventArgs> SystemSettingsAccessibilityTtsSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.AccessibilityTtsSettingChangedEventArgs>, global::Tizen.System.AccessibilityTtsSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.AccessibilityTtsSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.AccessibilityTtsSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8257,9 +8257,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.AdsIdChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.AdsIdChangedEventArgs)> SystemSettingsAdsIdChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.AdsIdChangedEventArgs>, (object, global::Tizen.System.AdsIdChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.AdsIdChangedEventArgs> SystemSettingsAdsIdChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.AdsIdChangedEventArgs>, global::Tizen.System.AdsIdChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.AdsIdChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.AdsIdChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8267,9 +8267,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.Data3GNetworkSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.Data3GNetworkSettingChangedEventArgs)> SystemSettingsData3GNetworkSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.Data3GNetworkSettingChangedEventArgs>, (object, global::Tizen.System.Data3GNetworkSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.Data3GNetworkSettingChangedEventArgs> SystemSettingsData3GNetworkSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.Data3GNetworkSettingChangedEventArgs>, global::Tizen.System.Data3GNetworkSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.Data3GNetworkSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.Data3GNetworkSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8277,9 +8277,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.DeviceNameChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.DeviceNameChangedEventArgs)> SystemSettingsDeviceNameChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.DeviceNameChangedEventArgs>, (object, global::Tizen.System.DeviceNameChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.DeviceNameChangedEventArgs> SystemSettingsDeviceNameChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.DeviceNameChangedEventArgs>, global::Tizen.System.DeviceNameChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.DeviceNameChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.DeviceNameChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8287,9 +8287,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.DisplayScreenRotationAutoSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.DisplayScreenRotationAutoSettingChangedEventArgs)> SystemSettingsDisplayScreenRotationAutoSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.DisplayScreenRotationAutoSettingChangedEventArgs>, (object, global::Tizen.System.DisplayScreenRotationAutoSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.DisplayScreenRotationAutoSettingChangedEventArgs> SystemSettingsDisplayScreenRotationAutoSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.DisplayScreenRotationAutoSettingChangedEventArgs>, global::Tizen.System.DisplayScreenRotationAutoSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.DisplayScreenRotationAutoSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.DisplayScreenRotationAutoSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8297,9 +8297,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.EmailAlertRingtoneChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.EmailAlertRingtoneChangedEventArgs)> SystemSettingsEmailAlertRingtoneChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.EmailAlertRingtoneChangedEventArgs>, (object, global::Tizen.System.EmailAlertRingtoneChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.EmailAlertRingtoneChangedEventArgs> SystemSettingsEmailAlertRingtoneChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.EmailAlertRingtoneChangedEventArgs>, global::Tizen.System.EmailAlertRingtoneChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.EmailAlertRingtoneChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.EmailAlertRingtoneChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8307,9 +8307,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.FontSizeChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.FontSizeChangedEventArgs)> SystemSettingsFontSizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.FontSizeChangedEventArgs>, (object, global::Tizen.System.FontSizeChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.FontSizeChangedEventArgs> SystemSettingsFontSizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.FontSizeChangedEventArgs>, global::Tizen.System.FontSizeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.FontSizeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.FontSizeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8317,9 +8317,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.FontTypeChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.FontTypeChangedEventArgs)> SystemSettingsFontTypeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.FontTypeChangedEventArgs>, (object, global::Tizen.System.FontTypeChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.FontTypeChangedEventArgs> SystemSettingsFontTypeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.FontTypeChangedEventArgs>, global::Tizen.System.FontTypeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.FontTypeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.FontTypeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8327,9 +8327,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.IncomingCallRingtoneChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.IncomingCallRingtoneChangedEventArgs)> SystemSettingsIncomingCallRingtoneChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.IncomingCallRingtoneChangedEventArgs>, (object, global::Tizen.System.IncomingCallRingtoneChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.IncomingCallRingtoneChangedEventArgs> SystemSettingsIncomingCallRingtoneChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.IncomingCallRingtoneChangedEventArgs>, global::Tizen.System.IncomingCallRingtoneChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.IncomingCallRingtoneChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.IncomingCallRingtoneChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8337,9 +8337,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.LocaleCountryChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.LocaleCountryChangedEventArgs)> SystemSettingsLocaleCountryChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LocaleCountryChangedEventArgs>, (object, global::Tizen.System.LocaleCountryChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.LocaleCountryChangedEventArgs> SystemSettingsLocaleCountryChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LocaleCountryChangedEventArgs>, global::Tizen.System.LocaleCountryChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.LocaleCountryChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.LocaleCountryChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8347,9 +8347,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.LocaleLanguageChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.LocaleLanguageChangedEventArgs)> SystemSettingsLocaleLanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LocaleLanguageChangedEventArgs>, (object, global::Tizen.System.LocaleLanguageChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.LocaleLanguageChangedEventArgs> SystemSettingsLocaleLanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LocaleLanguageChangedEventArgs>, global::Tizen.System.LocaleLanguageChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.LocaleLanguageChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.LocaleLanguageChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8357,9 +8357,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.LocaleTimeFormat24HourSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.LocaleTimeFormat24HourSettingChangedEventArgs)> SystemSettingsLocaleTimeFormat24HourSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LocaleTimeFormat24HourSettingChangedEventArgs>, (object, global::Tizen.System.LocaleTimeFormat24HourSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.LocaleTimeFormat24HourSettingChangedEventArgs> SystemSettingsLocaleTimeFormat24HourSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LocaleTimeFormat24HourSettingChangedEventArgs>, global::Tizen.System.LocaleTimeFormat24HourSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.LocaleTimeFormat24HourSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.LocaleTimeFormat24HourSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8367,9 +8367,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.LocaleTimeZoneChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.LocaleTimeZoneChangedEventArgs)> SystemSettingsLocaleTimeZoneChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LocaleTimeZoneChangedEventArgs>, (object, global::Tizen.System.LocaleTimeZoneChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.LocaleTimeZoneChangedEventArgs> SystemSettingsLocaleTimeZoneChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LocaleTimeZoneChangedEventArgs>, global::Tizen.System.LocaleTimeZoneChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.LocaleTimeZoneChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.LocaleTimeZoneChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8377,9 +8377,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.LockScreenAppChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.LockScreenAppChangedEventArgs)> SystemSettingsLockScreenAppChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LockScreenAppChangedEventArgs>, (object, global::Tizen.System.LockScreenAppChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.LockScreenAppChangedEventArgs> SystemSettingsLockScreenAppChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LockScreenAppChangedEventArgs>, global::Tizen.System.LockScreenAppChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.LockScreenAppChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.LockScreenAppChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8387,9 +8387,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.LockStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.LockStateChangedEventArgs)> SystemSettingsLockStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LockStateChangedEventArgs>, (object, global::Tizen.System.LockStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.LockStateChangedEventArgs> SystemSettingsLockStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.LockStateChangedEventArgs>, global::Tizen.System.LockStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.LockStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.LockStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8397,9 +8397,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.MotionActivationSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.MotionActivationSettingChangedEventArgs)> SystemSettingsMotionActivationSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.MotionActivationSettingChangedEventArgs>, (object, global::Tizen.System.MotionActivationSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.MotionActivationSettingChangedEventArgs> SystemSettingsMotionActivationSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.MotionActivationSettingChangedEventArgs>, global::Tizen.System.MotionActivationSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.MotionActivationSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.MotionActivationSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8407,9 +8407,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.MotionSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.MotionSettingChangedEventArgs)> SystemSettingsMotionSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.MotionSettingChangedEventArgs>, (object, global::Tizen.System.MotionSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.MotionSettingChangedEventArgs> SystemSettingsMotionSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.MotionSettingChangedEventArgs>, global::Tizen.System.MotionSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.MotionSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.MotionSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8417,9 +8417,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.NetworkFlightModeSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.NetworkFlightModeSettingChangedEventArgs)> SystemSettingsNetworkFlightModeSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.NetworkFlightModeSettingChangedEventArgs>, (object, global::Tizen.System.NetworkFlightModeSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.NetworkFlightModeSettingChangedEventArgs> SystemSettingsNetworkFlightModeSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.NetworkFlightModeSettingChangedEventArgs>, global::Tizen.System.NetworkFlightModeSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.NetworkFlightModeSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.NetworkFlightModeSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8427,9 +8427,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.NetworkWifiNotificationSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.NetworkWifiNotificationSettingChangedEventArgs)> SystemSettingsNetworkWifiNotificationSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.NetworkWifiNotificationSettingChangedEventArgs>, (object, global::Tizen.System.NetworkWifiNotificationSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.NetworkWifiNotificationSettingChangedEventArgs> SystemSettingsNetworkWifiNotificationSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.NetworkWifiNotificationSettingChangedEventArgs>, global::Tizen.System.NetworkWifiNotificationSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.NetworkWifiNotificationSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.NetworkWifiNotificationSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8437,9 +8437,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.ScreenBacklightTimeChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.ScreenBacklightTimeChangedEventArgs)> SystemSettingsScreenBacklightTimeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.ScreenBacklightTimeChangedEventArgs>, (object, global::Tizen.System.ScreenBacklightTimeChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.ScreenBacklightTimeChangedEventArgs> SystemSettingsScreenBacklightTimeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.ScreenBacklightTimeChangedEventArgs>, global::Tizen.System.ScreenBacklightTimeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.ScreenBacklightTimeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.ScreenBacklightTimeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8447,9 +8447,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.SoundLockSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.SoundLockSettingChangedEventArgs)> SystemSettingsSoundLockSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundLockSettingChangedEventArgs>, (object, global::Tizen.System.SoundLockSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.SoundLockSettingChangedEventArgs> SystemSettingsSoundLockSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundLockSettingChangedEventArgs>, global::Tizen.System.SoundLockSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.SoundLockSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.SoundLockSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8457,9 +8457,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.SoundNotificationChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.SoundNotificationChangedEventArgs)> SystemSettingsSoundNotificationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundNotificationChangedEventArgs>, (object, global::Tizen.System.SoundNotificationChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.SoundNotificationChangedEventArgs> SystemSettingsSoundNotificationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundNotificationChangedEventArgs>, global::Tizen.System.SoundNotificationChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.SoundNotificationChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.SoundNotificationChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8467,9 +8467,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.SoundNotificationRepetitionPeriodChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.SoundNotificationRepetitionPeriodChangedEventArgs)> SystemSettingsSoundNotificationRepetitionPeriodChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundNotificationRepetitionPeriodChangedEventArgs>, (object, global::Tizen.System.SoundNotificationRepetitionPeriodChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.SoundNotificationRepetitionPeriodChangedEventArgs> SystemSettingsSoundNotificationRepetitionPeriodChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundNotificationRepetitionPeriodChangedEventArgs>, global::Tizen.System.SoundNotificationRepetitionPeriodChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.SoundNotificationRepetitionPeriodChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.SoundNotificationRepetitionPeriodChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8477,9 +8477,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.SoundSilentModeSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.SoundSilentModeSettingChangedEventArgs)> SystemSettingsSoundSilentModeSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundSilentModeSettingChangedEventArgs>, (object, global::Tizen.System.SoundSilentModeSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.SoundSilentModeSettingChangedEventArgs> SystemSettingsSoundSilentModeSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundSilentModeSettingChangedEventArgs>, global::Tizen.System.SoundSilentModeSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.SoundSilentModeSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.SoundSilentModeSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8487,9 +8487,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.SoundTouchSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.SoundTouchSettingChangedEventArgs)> SystemSettingsSoundTouchSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundTouchSettingChangedEventArgs>, (object, global::Tizen.System.SoundTouchSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.SoundTouchSettingChangedEventArgs> SystemSettingsSoundTouchSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.SoundTouchSettingChangedEventArgs>, global::Tizen.System.SoundTouchSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.SoundTouchSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.SoundTouchSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8497,9 +8497,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.TimeChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.TimeChangedEventArgs)> SystemSettingsTimeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.TimeChangedEventArgs>, (object, global::Tizen.System.TimeChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.TimeChangedEventArgs> SystemSettingsTimeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.TimeChangedEventArgs>, global::Tizen.System.TimeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.TimeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.TimeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8507,9 +8507,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.UltraDataSaveChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.UltraDataSaveChangedEventArgs)> SystemSettingsUltraDataSaveChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.UltraDataSaveChangedEventArgs>, (object, global::Tizen.System.UltraDataSaveChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.UltraDataSaveChangedEventArgs> SystemSettingsUltraDataSaveChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.UltraDataSaveChangedEventArgs>, global::Tizen.System.UltraDataSaveChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.UltraDataSaveChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.UltraDataSaveChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8517,9 +8517,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.UltraDataSavePackageListChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.UltraDataSavePackageListChangedEventArgs)> SystemSettingsUltraDataSavePackageListChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.UltraDataSavePackageListChangedEventArgs>, (object, global::Tizen.System.UltraDataSavePackageListChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.UltraDataSavePackageListChangedEventArgs> SystemSettingsUltraDataSavePackageListChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.UltraDataSavePackageListChangedEventArgs>, global::Tizen.System.UltraDataSavePackageListChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.UltraDataSavePackageListChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.UltraDataSavePackageListChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8527,9 +8527,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.UsbDebuggingSettingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.UsbDebuggingSettingChangedEventArgs)> SystemSettingsUsbDebuggingSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.UsbDebuggingSettingChangedEventArgs>, (object, global::Tizen.System.UsbDebuggingSettingChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.UsbDebuggingSettingChangedEventArgs> SystemSettingsUsbDebuggingSettingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.UsbDebuggingSettingChangedEventArgs>, global::Tizen.System.UsbDebuggingSettingChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.UsbDebuggingSettingChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.UsbDebuggingSettingChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8537,9 +8537,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.WallpaperHomeScreenChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.WallpaperHomeScreenChangedEventArgs)> SystemSettingsWallpaperHomeScreenChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.WallpaperHomeScreenChangedEventArgs>, (object, global::Tizen.System.WallpaperHomeScreenChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.WallpaperHomeScreenChangedEventArgs> SystemSettingsWallpaperHomeScreenChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.WallpaperHomeScreenChangedEventArgs>, global::Tizen.System.WallpaperHomeScreenChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.WallpaperHomeScreenChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.WallpaperHomeScreenChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8547,9 +8547,9 @@ namespace Tizen.System
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.System.SystemSettings.WallpaperLockScreenChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.System.WallpaperLockScreenChangedEventArgs)> SystemSettingsWallpaperLockScreenChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.WallpaperLockScreenChangedEventArgs>, (object, global::Tizen.System.WallpaperLockScreenChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.System.WallpaperLockScreenChangedEventArgs> SystemSettingsWallpaperLockScreenChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.System.WallpaperLockScreenChangedEventArgs>, global::Tizen.System.WallpaperLockScreenChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.System.WallpaperLockScreenChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.System.WallpaperLockScreenChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8567,9 +8567,9 @@ namespace Tizen.Telephony
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Telephony.Manager.StateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Telephony.StateEventArgs)> ManagerStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Telephony.StateEventArgs>, (object, global::Tizen.Telephony.StateEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Telephony.StateEventArgs> ManagerStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Telephony.StateEventArgs>, global::Tizen.Telephony.StateEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Telephony.StateEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Telephony.StateEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8587,9 +8587,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.AccessibilityStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.AccessibilityStateChangedEventArgs)> InputMethodEditorAccessibilityStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.AccessibilityStateChangedEventArgs>, (object, global::Tizen.Uix.InputMethod.AccessibilityStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.AccessibilityStateChangedEventArgs> InputMethodEditorAccessibilityStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.AccessibilityStateChangedEventArgs>, global::Tizen.Uix.InputMethod.AccessibilityStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.AccessibilityStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.AccessibilityStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8597,9 +8597,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.CursorPositionUpdated"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.CursorPositionUpdatedEventArgs)> InputMethodEditorCursorPositionUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.CursorPositionUpdatedEventArgs>, (object, global::Tizen.Uix.InputMethod.CursorPositionUpdatedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.CursorPositionUpdatedEventArgs> InputMethodEditorCursorPositionUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.CursorPositionUpdatedEventArgs>, global::Tizen.Uix.InputMethod.CursorPositionUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.CursorPositionUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.CursorPositionUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8607,9 +8607,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.DataSet"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.SetDataEventArgs)> InputMethodEditorDataSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.SetDataEventArgs>, (object, global::Tizen.Uix.InputMethod.SetDataEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.SetDataEventArgs> InputMethodEditorDataSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.SetDataEventArgs>, global::Tizen.Uix.InputMethod.SetDataEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.SetDataEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.SetDataEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8617,9 +8617,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.DisplayLanguageChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.DisplayLanguageChangedEventArgs)> InputMethodEditorDisplayLanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.DisplayLanguageChangedEventArgs>, (object, global::Tizen.Uix.InputMethod.DisplayLanguageChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.DisplayLanguageChangedEventArgs> InputMethodEditorDisplayLanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.DisplayLanguageChangedEventArgs>, global::Tizen.Uix.InputMethod.DisplayLanguageChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.DisplayLanguageChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.DisplayLanguageChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8627,9 +8627,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.FocusedIn"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.FocusedInEventArgs)> InputMethodEditorFocusedIn => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.FocusedInEventArgs>, (object, global::Tizen.Uix.InputMethod.FocusedInEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.FocusedInEventArgs> InputMethodEditorFocusedIn => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.FocusedInEventArgs>, global::Tizen.Uix.InputMethod.FocusedInEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.FocusedInEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.FocusedInEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8637,9 +8637,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.FocusedOut"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.FocusedOutEventArgs)> InputMethodEditorFocusedOut => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.FocusedOutEventArgs>, (object, global::Tizen.Uix.InputMethod.FocusedOutEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.FocusedOutEventArgs> InputMethodEditorFocusedOut => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.FocusedOutEventArgs>, global::Tizen.Uix.InputMethod.FocusedOutEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.FocusedOutEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.FocusedOutEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8647,9 +8647,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.InputContextReset"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::System.EventArgs)> InputMethodEditorInputContextReset => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, (object, global::System.EventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::System.EventArgs> InputMethodEditorInputContextReset => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8657,9 +8657,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.LanguageSet"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.LanguageSetEventArgs)> InputMethodEditorLanguageSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.LanguageSetEventArgs>, (object, global::Tizen.Uix.InputMethod.LanguageSetEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.LanguageSetEventArgs> InputMethodEditorLanguageSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.LanguageSetEventArgs>, global::Tizen.Uix.InputMethod.LanguageSetEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.LanguageSetEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.LanguageSetEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8667,9 +8667,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.LayoutSet"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.LayoutSetEventArgs)> InputMethodEditorLayoutSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.LayoutSetEventArgs>, (object, global::Tizen.Uix.InputMethod.LayoutSetEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.LayoutSetEventArgs> InputMethodEditorLayoutSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.LayoutSetEventArgs>, global::Tizen.Uix.InputMethod.LayoutSetEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.LayoutSetEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.LayoutSetEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8677,9 +8677,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.ReturnKeySet"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.ReturnKeySetEventArgs)> InputMethodEditorReturnKeySet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.ReturnKeySetEventArgs>, (object, global::Tizen.Uix.InputMethod.ReturnKeySetEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.ReturnKeySetEventArgs> InputMethodEditorReturnKeySet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.ReturnKeySetEventArgs>, global::Tizen.Uix.InputMethod.ReturnKeySetEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.ReturnKeySetEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.ReturnKeySetEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8687,9 +8687,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.ReturnKeyStateSet"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.ReturnKeyStateSetEventArgs)> InputMethodEditorReturnKeyStateSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.ReturnKeyStateSetEventArgs>, (object, global::Tizen.Uix.InputMethod.ReturnKeyStateSetEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.ReturnKeyStateSetEventArgs> InputMethodEditorReturnKeyStateSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.ReturnKeyStateSetEventArgs>, global::Tizen.Uix.InputMethod.ReturnKeyStateSetEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.ReturnKeyStateSetEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.ReturnKeyStateSetEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8697,9 +8697,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.RotationChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.RotationChangedEventArgs)> InputMethodEditorRotationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.RotationChangedEventArgs>, (object, global::Tizen.Uix.InputMethod.RotationChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.RotationChangedEventArgs> InputMethodEditorRotationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.RotationChangedEventArgs>, global::Tizen.Uix.InputMethod.RotationChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.RotationChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.RotationChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8707,9 +8707,9 @@ namespace Tizen.Uix.InputMethod
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.InputMethod.InputMethodEditor.SurroundingTextUpdated"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.InputMethod.SurroundingTextUpdatedEventArgs)> InputMethodEditorSurroundingTextUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.SurroundingTextUpdatedEventArgs>, (object, global::Tizen.Uix.InputMethod.SurroundingTextUpdatedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.InputMethod.SurroundingTextUpdatedEventArgs> InputMethodEditorSurroundingTextUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.InputMethod.SurroundingTextUpdatedEventArgs>, global::Tizen.Uix.InputMethod.SurroundingTextUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.InputMethod.SurroundingTextUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.InputMethod.SurroundingTextUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8727,9 +8727,9 @@ namespace Tizen.Uix.VoiceControl
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.VoiceControl.VoiceControlClient.CurrentLanguageChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.VoiceControl.CurrentLanguageChangedEventArgs)> VoiceControlClientCurrentLanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.CurrentLanguageChangedEventArgs>, (object, global::Tizen.Uix.VoiceControl.CurrentLanguageChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.VoiceControl.CurrentLanguageChangedEventArgs> VoiceControlClientCurrentLanguageChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.CurrentLanguageChangedEventArgs>, global::Tizen.Uix.VoiceControl.CurrentLanguageChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.VoiceControl.CurrentLanguageChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.VoiceControl.CurrentLanguageChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8737,9 +8737,9 @@ namespace Tizen.Uix.VoiceControl
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.VoiceControl.VoiceControlClient.ErrorOccured"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.VoiceControl.ErrorOccuredEventArgs)> VoiceControlClientErrorOccured => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.ErrorOccuredEventArgs>, (object, global::Tizen.Uix.VoiceControl.ErrorOccuredEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.VoiceControl.ErrorOccuredEventArgs> VoiceControlClientErrorOccured => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.ErrorOccuredEventArgs>, global::Tizen.Uix.VoiceControl.ErrorOccuredEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.VoiceControl.ErrorOccuredEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.VoiceControl.ErrorOccuredEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8747,9 +8747,9 @@ namespace Tizen.Uix.VoiceControl
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.VoiceControl.VoiceControlClient.RecognitionResult"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.VoiceControl.RecognitionResultEventArgs)> VoiceControlClientRecognitionResult => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.RecognitionResultEventArgs>, (object, global::Tizen.Uix.VoiceControl.RecognitionResultEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.VoiceControl.RecognitionResultEventArgs> VoiceControlClientRecognitionResult => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.RecognitionResultEventArgs>, global::Tizen.Uix.VoiceControl.RecognitionResultEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.VoiceControl.RecognitionResultEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.VoiceControl.RecognitionResultEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8757,9 +8757,9 @@ namespace Tizen.Uix.VoiceControl
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.VoiceControl.VoiceControlClient.ServiceStateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.VoiceControl.ServiceStateChangedEventArgs)> VoiceControlClientServiceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.ServiceStateChangedEventArgs>, (object, global::Tizen.Uix.VoiceControl.ServiceStateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.VoiceControl.ServiceStateChangedEventArgs> VoiceControlClientServiceStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.ServiceStateChangedEventArgs>, global::Tizen.Uix.VoiceControl.ServiceStateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.VoiceControl.ServiceStateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.VoiceControl.ServiceStateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -8767,9 +8767,9 @@ namespace Tizen.Uix.VoiceControl
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Tizen.Uix.VoiceControl.VoiceControlClient.StateChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Tizen.Uix.VoiceControl.StateChangedEventArgs)> VoiceControlClientStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.StateChangedEventArgs>, (object, global::Tizen.Uix.VoiceControl.StateChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Tizen.Uix.VoiceControl.StateChangedEventArgs> VoiceControlClientStateChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Tizen.Uix.VoiceControl.StateChangedEventArgs>, global::Tizen.Uix.VoiceControl.StateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Tizen.Uix.VoiceControl.StateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Tizen.Uix.VoiceControl.StateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 

--- a/src/Pharmacist.Tests/IntegrationTests/Approved/Xamarin.Essentials.1.1.0.approved.txt
+++ b/src/Pharmacist.Tests/IntegrationTests/Approved/Xamarin.Essentials.1.1.0.approved.txt
@@ -9,9 +9,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Accelerometer.ReadingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.AccelerometerChangedEventArgs)> AccelerometerReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.AccelerometerChangedEventArgs>, (object, global::Xamarin.Essentials.AccelerometerChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.AccelerometerChangedEventArgs> AccelerometerReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.AccelerometerChangedEventArgs>, global::Xamarin.Essentials.AccelerometerChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.AccelerometerChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.AccelerometerChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -19,9 +19,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Accelerometer.ShakeDetected"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::System.EventArgs)> AccelerometerShakeDetected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::System.EventArgs> AccelerometerShakeDetected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -29,9 +29,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Barometer.ReadingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.BarometerChangedEventArgs)> BarometerReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.BarometerChangedEventArgs>, (object, global::Xamarin.Essentials.BarometerChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.BarometerChangedEventArgs> BarometerReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.BarometerChangedEventArgs>, global::Xamarin.Essentials.BarometerChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.BarometerChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.BarometerChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -39,9 +39,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Battery.BatteryInfoChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.BatteryInfoChangedEventArgs)> BatteryBatteryInfoChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.BatteryInfoChangedEventArgs>, (object, global::Xamarin.Essentials.BatteryInfoChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.BatteryInfoChangedEventArgs> BatteryBatteryInfoChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.BatteryInfoChangedEventArgs>, global::Xamarin.Essentials.BatteryInfoChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.BatteryInfoChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.BatteryInfoChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -49,9 +49,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Battery.EnergySaverStatusChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.EnergySaverStatusChangedEventArgs)> BatteryEnergySaverStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.EnergySaverStatusChangedEventArgs>, (object, global::Xamarin.Essentials.EnergySaverStatusChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.EnergySaverStatusChangedEventArgs> BatteryEnergySaverStatusChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.EnergySaverStatusChangedEventArgs>, global::Xamarin.Essentials.EnergySaverStatusChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.EnergySaverStatusChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.EnergySaverStatusChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -59,9 +59,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Compass.ReadingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.CompassChangedEventArgs)> CompassReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.CompassChangedEventArgs>, (object, global::Xamarin.Essentials.CompassChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.CompassChangedEventArgs> CompassReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.CompassChangedEventArgs>, global::Xamarin.Essentials.CompassChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.CompassChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.CompassChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -69,9 +69,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Connectivity.ConnectivityChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.ConnectivityChangedEventArgs)> ConnectivityConnectivityChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.ConnectivityChangedEventArgs>, (object, global::Xamarin.Essentials.ConnectivityChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.ConnectivityChangedEventArgs> ConnectivityConnectivityChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.ConnectivityChangedEventArgs>, global::Xamarin.Essentials.ConnectivityChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.ConnectivityChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.ConnectivityChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -79,9 +79,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.DeviceDisplay.MainDisplayInfoChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.DisplayInfoChangedEventArgs)> DeviceDisplayMainDisplayInfoChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.DisplayInfoChangedEventArgs>, (object, global::Xamarin.Essentials.DisplayInfoChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.DisplayInfoChangedEventArgs> DeviceDisplayMainDisplayInfoChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.DisplayInfoChangedEventArgs>, global::Xamarin.Essentials.DisplayInfoChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.DisplayInfoChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.DisplayInfoChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -89,9 +89,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Gyroscope.ReadingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.GyroscopeChangedEventArgs)> GyroscopeReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.GyroscopeChangedEventArgs>, (object, global::Xamarin.Essentials.GyroscopeChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.GyroscopeChangedEventArgs> GyroscopeReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.GyroscopeChangedEventArgs>, global::Xamarin.Essentials.GyroscopeChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.GyroscopeChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.GyroscopeChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -99,9 +99,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.Magnetometer.ReadingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.MagnetometerChangedEventArgs)> MagnetometerReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.MagnetometerChangedEventArgs>, (object, global::Xamarin.Essentials.MagnetometerChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.MagnetometerChangedEventArgs> MagnetometerReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.MagnetometerChangedEventArgs>, global::Xamarin.Essentials.MagnetometerChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.MagnetometerChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.MagnetometerChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -109,9 +109,9 @@ namespace Xamarin.Essentials
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Essentials.OrientationSensor.ReadingChanged"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Essentials.OrientationSensorChangedEventArgs)> OrientationSensorReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.OrientationSensorChangedEventArgs>, (object, global::Xamarin.Essentials.OrientationSensorChangedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Essentials.OrientationSensorChangedEventArgs> OrientationSensorReadingChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Essentials.OrientationSensorChangedEventArgs>, global::Xamarin.Essentials.OrientationSensorChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Essentials.OrientationSensorChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Essentials.OrientationSensorChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 

--- a/src/Pharmacist.Tests/IntegrationTests/Approved/Xamarin.Forms.4.0.0.482894.approved.txt
+++ b/src/Pharmacist.Tests/IntegrationTests/Approved/Xamarin.Forms.4.0.0.482894.approved.txt
@@ -254,9 +254,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.ModalPopped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ModalPoppedEventArgs)> ModalPopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPoppedEventArgs>, (object, global::Xamarin.Forms.ModalPoppedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ModalPoppedEventArgs> ModalPopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPoppedEventArgs>, global::Xamarin.Forms.ModalPoppedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ModalPoppedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ModalPoppedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -264,9 +264,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.ModalPopping"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ModalPoppingEventArgs)> ModalPopping => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPoppingEventArgs>, (object, global::Xamarin.Forms.ModalPoppingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ModalPoppingEventArgs> ModalPopping => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPoppingEventArgs>, global::Xamarin.Forms.ModalPoppingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ModalPoppingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ModalPoppingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -274,9 +274,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.ModalPushed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ModalPushedEventArgs)> ModalPushed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPushedEventArgs>, (object, global::Xamarin.Forms.ModalPushedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ModalPushedEventArgs> ModalPushed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPushedEventArgs>, global::Xamarin.Forms.ModalPushedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ModalPushedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ModalPushedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -284,9 +284,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.ModalPushing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ModalPushingEventArgs)> ModalPushing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPushingEventArgs>, (object, global::Xamarin.Forms.ModalPushingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ModalPushingEventArgs> ModalPushing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPushingEventArgs>, global::Xamarin.Forms.ModalPushingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ModalPushingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ModalPushingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -294,9 +294,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.PageAppearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Page)> PageAppearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Page>, (object, global::Xamarin.Forms.Page)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Page> PageAppearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Page>, global::Xamarin.Forms.Page>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Page e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Page e) => eventHandler(e);
             return Handler;
         }
 
@@ -304,9 +304,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.PageDisappearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Page)> PageDisappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Page>, (object, global::Xamarin.Forms.Page)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Page> PageDisappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Page>, global::Xamarin.Forms.Page>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Page e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Page e) => eventHandler(e);
             return Handler;
         }
 
@@ -331,9 +331,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.BindableObject.BindingContextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> BindingContextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> BindingContextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -341,9 +341,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.BindableObject.PropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -351,9 +351,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.BindableObject.PropertyChanging"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.PropertyChangingEventArgs)> PropertyChanging => global::System.Reactive.Linq.Observable.FromEvent<global::Xamarin.Forms.PropertyChangingEventHandler, (object, global::Xamarin.Forms.PropertyChangingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.PropertyChangingEventArgs> PropertyChanging => global::System.Reactive.Linq.Observable.FromEvent<global::Xamarin.Forms.PropertyChangingEventHandler, global::Xamarin.Forms.PropertyChangingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.PropertyChangingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.PropertyChangingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -378,9 +378,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Button.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -388,9 +388,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Button.Pressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -398,9 +398,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Button.Released"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -425,9 +425,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Cell.Appearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Appearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Appearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -435,9 +435,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Cell.Disappearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Disappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Disappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -445,9 +445,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Cell.ForceUpdateSizeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ForceUpdateSizeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ForceUpdateSizeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -455,9 +455,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Cell.Tapped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Tapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Tapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -482,9 +482,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ChildGestureRecognizer.PropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -509,9 +509,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ClickGestureRecognizer.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -536,9 +536,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ColumnDefinition.SizeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -563,9 +563,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Command.CanExecuteChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> CanExecuteChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> CanExecuteChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -590,9 +590,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.DatePicker.DateSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.DateChangedEventArgs)> DateSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.DateChangedEventArgs>, (object, global::Xamarin.Forms.DateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.DateChangedEventArgs> DateSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.DateChangedEventArgs>, global::Xamarin.Forms.DateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.DateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.DateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -617,9 +617,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Editor.Completed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -627,9 +627,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Editor.TextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.TextChangedEventArgs)> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, (object, global::Xamarin.Forms.TextChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.TextChangedEventArgs> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, global::Xamarin.Forms.TextChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -654,9 +654,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.ChildAdded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ElementEventArgs)> ChildAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, (object, global::Xamarin.Forms.ElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ElementEventArgs> ChildAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, global::Xamarin.Forms.ElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -664,9 +664,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.ChildRemoved"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ElementEventArgs)> ChildRemoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, (object, global::Xamarin.Forms.ElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ElementEventArgs> ChildRemoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, global::Xamarin.Forms.ElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -674,9 +674,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.DescendantAdded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ElementEventArgs)> DescendantAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, (object, global::Xamarin.Forms.ElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ElementEventArgs> DescendantAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, global::Xamarin.Forms.ElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -684,9 +684,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.DescendantRemoved"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ElementEventArgs)> DescendantRemoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, (object, global::Xamarin.Forms.ElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ElementEventArgs> DescendantRemoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, global::Xamarin.Forms.ElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -695,9 +695,9 @@ namespace Xamarin.Forms
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.PlatformSet"/> event triggers.
         /// </summary>
         [global::System.ObsoleteAttribute("PlatformSet is obsolete as of 3.5.0. Do not use this event.", false)]
-        public global::System.IObservable<(object, global::System.EventArgs)> PlatformSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> PlatformSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -722,9 +722,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Entry.Completed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -732,9 +732,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Entry.TextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.TextChangedEventArgs)> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, (object, global::Xamarin.Forms.TextChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.TextChangedEventArgs> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, global::Xamarin.Forms.TextChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -759,9 +759,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.EntryCell.Completed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -786,9 +786,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ICellController.ForceUpdateSizeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ForceUpdateSizeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ForceUpdateSizeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -813,9 +813,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IDefinition.SizeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -841,9 +841,9 @@ namespace Xamarin.Forms
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IElementController.PlatformSet"/> event triggers.
         /// </summary>
         [global::System.ObsoleteAttribute("PlatformSet is obsolete as of 3.5.0. Do not use this event.", false)]
-        public global::System.IObservable<(object, global::System.EventArgs)> PlatformSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> PlatformSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -868,9 +868,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ILayout.LayoutChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -895,9 +895,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IListProxy.CollectionChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs)> CollectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler, (object, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.Collections.Specialized.NotifyCollectionChangedEventArgs> CollectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -922,9 +922,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IListViewController.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestedEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestedEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, global::Xamarin.Forms.ScrollToRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -949,9 +949,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ImageButton.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -959,9 +959,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ImageButton.Pressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -969,9 +969,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ImageButton.Released"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -996,9 +996,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IMasterDetailPageController.BackButtonPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.BackButtonPressedEventArgs)> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.BackButtonPressedEventArgs>, (object, global::Xamarin.Forms.BackButtonPressedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.BackButtonPressedEventArgs> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.BackButtonPressedEventArgs>, global::Xamarin.Forms.BackButtonPressedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.BackButtonPressedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.BackButtonPressedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1023,9 +1023,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.InsertPageBeforeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> InsertPageBeforeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> InsertPageBeforeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1033,9 +1033,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.PopRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PopRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PopRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1043,9 +1043,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.PopToRootRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PopToRootRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PopToRootRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1053,9 +1053,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.PushRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PushRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PushRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1063,9 +1063,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.RemovePageRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> RemovePageRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> RemovePageRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1090,9 +1090,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IOpenGlViewController.DisplayRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DisplayRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DisplayRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1117,9 +1117,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IScrollViewController.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestedEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestedEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, global::Xamarin.Forms.ScrollToRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1144,9 +1144,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ISearchHandlerController.ListProxyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ListProxyChangedEventArgs)> ListProxyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ListProxyChangedEventArgs>, (object, global::Xamarin.Forms.ListProxyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ListProxyChangedEventArgs> ListProxyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ListProxyChangedEventArgs>, global::Xamarin.Forms.ListProxyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ListProxyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ListProxyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1171,9 +1171,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IShellController.StructureChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> StructureChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> StructureChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1198,9 +1198,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IShellSectionController.NavigationRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> NavigationRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> NavigationRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1225,9 +1225,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ITableViewController.ModelChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ModelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ModelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1252,9 +1252,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ItemsView.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestEventArgs>, global::Xamarin.Forms.ScrollToRequestEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1279,9 +1279,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IVisualElementController.BatchCommitted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>)> BatchCommitted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>, (object, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>> BatchCommitted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement> e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement> e) => eventHandler(e);
             return Handler;
         }
 
@@ -1289,9 +1289,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IVisualElementController.FocusChangeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, (object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.VisualElement.FocusRequestArgs> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, global::Xamarin.Forms.VisualElement.FocusRequestArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1316,9 +1316,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IWebViewController.EvalRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EvalRequested)> EvalRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EvalRequested>, (object, global::Xamarin.Forms.Internals.EvalRequested)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EvalRequested> EvalRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EvalRequested>, global::Xamarin.Forms.Internals.EvalRequested>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EvalRequested e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EvalRequested e) => eventHandler(e);
             return Handler;
         }
 
@@ -1326,9 +1326,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IWebViewController.GoBackRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> GoBackRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> GoBackRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1336,9 +1336,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IWebViewController.GoForwardRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> GoForwardRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> GoForwardRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1346,9 +1346,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IWebViewController.ReloadRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ReloadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ReloadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1373,9 +1373,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Layout.LayoutChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1400,9 +1400,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ItemAppearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ItemVisibilityEventArgs)> ItemAppearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemVisibilityEventArgs>, (object, global::Xamarin.Forms.ItemVisibilityEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ItemVisibilityEventArgs> ItemAppearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemVisibilityEventArgs>, global::Xamarin.Forms.ItemVisibilityEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ItemVisibilityEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ItemVisibilityEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1410,9 +1410,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ItemDisappearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ItemVisibilityEventArgs)> ItemDisappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemVisibilityEventArgs>, (object, global::Xamarin.Forms.ItemVisibilityEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ItemVisibilityEventArgs> ItemDisappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemVisibilityEventArgs>, global::Xamarin.Forms.ItemVisibilityEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ItemVisibilityEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ItemVisibilityEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1420,9 +1420,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.SelectedItemChangedEventArgs)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SelectedItemChangedEventArgs>, (object, global::Xamarin.Forms.SelectedItemChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.SelectedItemChangedEventArgs> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SelectedItemChangedEventArgs>, global::Xamarin.Forms.SelectedItemChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.SelectedItemChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.SelectedItemChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1430,9 +1430,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ItemTapped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ItemTappedEventArgs)> ItemTapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemTappedEventArgs>, (object, global::Xamarin.Forms.ItemTappedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ItemTappedEventArgs> ItemTapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemTappedEventArgs>, global::Xamarin.Forms.ItemTappedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ItemTappedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ItemTappedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1440,9 +1440,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.Refreshing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Refreshing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Refreshing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1450,9 +1450,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestedEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestedEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, global::Xamarin.Forms.ScrollToRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1477,9 +1477,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.MasterDetailPage.BackButtonPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.BackButtonPressedEventArgs)> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.BackButtonPressedEventArgs>, (object, global::Xamarin.Forms.BackButtonPressedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.BackButtonPressedEventArgs> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.BackButtonPressedEventArgs>, global::Xamarin.Forms.BackButtonPressedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.BackButtonPressedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.BackButtonPressedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1487,9 +1487,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.MasterDetailPage.IsPresentedChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> IsPresentedChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> IsPresentedChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1514,9 +1514,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.MenuItem.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1541,9 +1541,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.InsertPageBeforeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> InsertPageBeforeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> InsertPageBeforeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1551,9 +1551,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.Popped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.NavigationEventArgs)> Popped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, (object, global::Xamarin.Forms.NavigationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.NavigationEventArgs> Popped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, global::Xamarin.Forms.NavigationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1561,9 +1561,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.PoppedToRoot"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.NavigationEventArgs)> PoppedToRoot => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, (object, global::Xamarin.Forms.NavigationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.NavigationEventArgs> PoppedToRoot => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, global::Xamarin.Forms.NavigationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1571,9 +1571,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.PopRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PopRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PopRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1581,9 +1581,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.PopToRootRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PopToRootRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PopToRootRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1591,9 +1591,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.Pushed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.NavigationEventArgs)> Pushed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, (object, global::Xamarin.Forms.NavigationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.NavigationEventArgs> Pushed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, global::Xamarin.Forms.NavigationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1601,9 +1601,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.PushRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PushRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PushRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1611,9 +1611,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.RemovePageRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> RemovePageRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> RemovePageRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1638,9 +1638,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.OpenGLView.DisplayRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DisplayRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DisplayRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1665,9 +1665,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Page.Appearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Appearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Appearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1675,9 +1675,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Page.Disappearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Disappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Disappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1685,9 +1685,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Page.LayoutChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1712,9 +1712,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.PanGestureRecognizer.PanUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.PanUpdatedEventArgs)> PanUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.PanUpdatedEventArgs>, (object, global::Xamarin.Forms.PanUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.PanUpdatedEventArgs> PanUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.PanUpdatedEventArgs>, global::Xamarin.Forms.PanUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.PanUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.PanUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1739,9 +1739,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Picker.SelectedIndexChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SelectedIndexChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SelectedIndexChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1766,9 +1766,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.PinchGestureRecognizer.PinchUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.PinchGestureUpdatedEventArgs)> PinchUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.PinchGestureUpdatedEventArgs>, (object, global::Xamarin.Forms.PinchGestureUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.PinchGestureUpdatedEventArgs> PinchUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.PinchGestureUpdatedEventArgs>, global::Xamarin.Forms.PinchGestureUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.PinchGestureUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.PinchGestureUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1793,9 +1793,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.RowDefinition.SizeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1820,9 +1820,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ScrollView.Scrolled"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrolledEventArgs)> Scrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrolledEventArgs>, (object, global::Xamarin.Forms.ScrolledEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrolledEventArgs> Scrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrolledEventArgs>, global::Xamarin.Forms.ScrolledEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrolledEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrolledEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1830,9 +1830,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ScrollView.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestedEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestedEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, global::Xamarin.Forms.ScrollToRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1857,9 +1857,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchBar.SearchButtonPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SearchButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SearchButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1867,9 +1867,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchBar.TextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.TextChangedEventArgs)> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, (object, global::Xamarin.Forms.TextChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.TextChangedEventArgs> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, global::Xamarin.Forms.TextChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1894,9 +1894,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchHandler.FocusChangeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, (object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.VisualElement.FocusRequestArgs> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, global::Xamarin.Forms.VisualElement.FocusRequestArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1904,9 +1904,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchHandler.Focused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1914,9 +1914,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchHandler.Unfocused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1941,9 +1941,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SelectableItemsView.SelectionChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.SelectionChangedEventArgs)> SelectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SelectionChangedEventArgs>, (object, global::Xamarin.Forms.SelectionChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.SelectionChangedEventArgs> SelectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SelectionChangedEventArgs>, global::Xamarin.Forms.SelectionChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.SelectionChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.SelectionChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1968,9 +1968,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Shell.Navigated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ShellNavigatedEventArgs)> Navigated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ShellNavigatedEventArgs>, (object, global::Xamarin.Forms.ShellNavigatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ShellNavigatedEventArgs> Navigated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ShellNavigatedEventArgs>, global::Xamarin.Forms.ShellNavigatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ShellNavigatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ShellNavigatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1978,9 +1978,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Shell.Navigating"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ShellNavigatingEventArgs)> Navigating => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ShellNavigatingEventArgs>, (object, global::Xamarin.Forms.ShellNavigatingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ShellNavigatingEventArgs> Navigating => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ShellNavigatingEventArgs>, global::Xamarin.Forms.ShellNavigatingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ShellNavigatingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ShellNavigatingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2005,9 +2005,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Slider.DragCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DragCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DragCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2015,9 +2015,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Slider.DragStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DragStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DragStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2025,9 +2025,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Slider.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ValueChangedEventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ValueChangedEventArgs>, (object, global::Xamarin.Forms.ValueChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ValueChangedEventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ValueChangedEventArgs>, global::Xamarin.Forms.ValueChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ValueChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ValueChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2052,9 +2052,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Stepper.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ValueChangedEventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ValueChangedEventArgs>, (object, global::Xamarin.Forms.ValueChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ValueChangedEventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ValueChangedEventArgs>, global::Xamarin.Forms.ValueChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ValueChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ValueChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2079,9 +2079,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SwipeGestureRecognizer.Swiped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.SwipedEventArgs)> Swiped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SwipedEventArgs>, (object, global::Xamarin.Forms.SwipedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.SwipedEventArgs> Swiped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SwipedEventArgs>, global::Xamarin.Forms.SwipedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.SwipedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.SwipedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2106,9 +2106,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Switch.Toggled"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ToggledEventArgs)> Toggled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ToggledEventArgs>, (object, global::Xamarin.Forms.ToggledEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ToggledEventArgs> Toggled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ToggledEventArgs>, global::Xamarin.Forms.ToggledEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ToggledEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ToggledEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2133,9 +2133,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SwitchCell.OnChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ToggledEventArgs)> OnChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ToggledEventArgs>, (object, global::Xamarin.Forms.ToggledEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ToggledEventArgs> OnChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ToggledEventArgs>, global::Xamarin.Forms.ToggledEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ToggledEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ToggledEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2160,9 +2160,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.TableView.ModelChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ModelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ModelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2187,9 +2187,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.TapGestureRecognizer.Tapped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Tapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Tapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2215,9 +2215,9 @@ namespace Xamarin.Forms
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ToolbarItem.Activated"/> event triggers.
         /// </summary>
         [global::System.ObsoleteAttribute("Activated is obsolete as of version 1.3.0. Please use Clicked instead.", false)]
-        public global::System.IObservable<(object, global::System.EventArgs)> Activated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Activated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2242,9 +2242,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.BatchCommitted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>)> BatchCommitted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>, (object, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>> BatchCommitted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement> e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement> e) => eventHandler(e);
             return Handler;
         }
 
@@ -2252,9 +2252,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.ChildrenReordered"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ChildrenReordered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ChildrenReordered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2262,9 +2262,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.FocusChangeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, (object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.VisualElement.FocusRequestArgs> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, global::Xamarin.Forms.VisualElement.FocusRequestArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2272,9 +2272,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.Focused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.FocusEventArgs)> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.FocusEventArgs>, (object, global::Xamarin.Forms.FocusEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.FocusEventArgs> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.FocusEventArgs>, global::Xamarin.Forms.FocusEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.FocusEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.FocusEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2282,9 +2282,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.MeasureInvalidated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> MeasureInvalidated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> MeasureInvalidated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2292,9 +2292,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.SizeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2302,9 +2302,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.Unfocused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.FocusEventArgs)> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.FocusEventArgs>, (object, global::Xamarin.Forms.FocusEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.FocusEventArgs> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.FocusEventArgs>, global::Xamarin.Forms.FocusEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.FocusEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.FocusEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2329,9 +2329,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.EvalRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EvalRequested)> EvalRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EvalRequested>, (object, global::Xamarin.Forms.Internals.EvalRequested)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EvalRequested> EvalRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EvalRequested>, global::Xamarin.Forms.Internals.EvalRequested>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EvalRequested e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EvalRequested e) => eventHandler(e);
             return Handler;
         }
 
@@ -2339,9 +2339,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.GoBackRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> GoBackRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> GoBackRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2349,9 +2349,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.GoForwardRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> GoForwardRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> GoForwardRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2359,9 +2359,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.Navigated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.WebNavigatedEventArgs)> Navigated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.WebNavigatedEventArgs>, (object, global::Xamarin.Forms.WebNavigatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.WebNavigatedEventArgs> Navigated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.WebNavigatedEventArgs>, global::Xamarin.Forms.WebNavigatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.WebNavigatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.WebNavigatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2369,9 +2369,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.Navigating"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.WebNavigatingEventArgs)> Navigating => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.WebNavigatingEventArgs>, (object, global::Xamarin.Forms.WebNavigatingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.WebNavigatingEventArgs> Navigating => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.WebNavigatingEventArgs>, global::Xamarin.Forms.WebNavigatingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.WebNavigatingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.WebNavigatingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2379,9 +2379,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.ReloadRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ReloadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ReloadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2432,9 +2432,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.DeviceInfo.PropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2459,9 +2459,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.IResourceDictionary.ValuesChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs)> ValuesChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.ResourcesChangedEventArgs>, (object, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.ResourcesChangedEventArgs> ValuesChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.ResourcesChangedEventArgs>, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2486,9 +2486,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.TableModel.ItemLongPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EventArg<object>)> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<object>>, (object, global::Xamarin.Forms.Internals.EventArg<object>)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EventArg<object>> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<object>>, global::Xamarin.Forms.Internals.EventArg<object>>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<object> e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<object> e) => eventHandler(e);
             return Handler;
         }
 
@@ -2496,9 +2496,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.TableModel.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EventArg<object>)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<object>>, (object, global::Xamarin.Forms.Internals.EventArg<object>)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EventArg<object>> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<object>>, global::Xamarin.Forms.Internals.EventArg<object>>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<object> e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<object> e) => eventHandler(e);
             return Handler;
         }
 
@@ -2523,9 +2523,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.ToolbarTracker.CollectionChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> CollectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> CollectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2628,9 +2628,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FormsAppCompatActivity.ConfigurationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2655,9 +2655,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FormsApplicationActivity.ConfigurationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2682,9 +2682,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IBorderVisualElementRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2709,9 +2709,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IButtonLayoutRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2736,9 +2736,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IDeviceInfoProvider.ConfigurationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2763,9 +2763,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ImageButtonRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2773,9 +2773,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ImageButtonRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2800,9 +2800,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IShellItemRenderer.Destroyed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2827,9 +2827,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IShellObservableFragment.AnimationFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2854,9 +2854,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IShellSearchView.SearchConfirmed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SearchConfirmed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SearchConfirmed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2881,9 +2881,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ItemsViewRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2891,9 +2891,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ItemsViewRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2918,9 +2918,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IVisualElementRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2928,9 +2928,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IVisualElementRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2955,9 +2955,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.MasterDetailRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2982,9 +2982,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ScrollViewRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3009,9 +3009,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ShellContentFragment.AnimationFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3036,9 +3036,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ShellItemRendererBase.Destroyed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3063,9 +3063,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ShellSearchView.SearchConfirmed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SearchConfirmed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SearchConfirmed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3090,9 +3090,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ShellSectionRenderer.AnimationFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3143,9 +3143,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3153,9 +3153,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3180,9 +3180,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.FrameRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3190,9 +3190,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.FrameRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3217,9 +3217,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3227,9 +3227,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3254,9 +3254,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3264,9 +3264,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3284,9 +3284,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Forms.ViewInitialized"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Forms.ViewInitializedEventArgs)> FormsViewInitialized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ViewInitializedEventArgs>, (object, global::Xamarin.Forms.ViewInitializedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Forms.ViewInitializedEventArgs> FormsViewInitialized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ViewInitializedEventArgs>, global::Xamarin.Forms.ViewInitializedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ViewInitializedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ViewInitializedEventArgs e) => eventHandler(e);
             return Handler;
         }
 

--- a/src/Pharmacist.Tests/IntegrationTests/Approved/Xamarin.Forms.4.0.0.497661.approved.txt
+++ b/src/Pharmacist.Tests/IntegrationTests/Approved/Xamarin.Forms.4.0.0.497661.approved.txt
@@ -254,9 +254,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.ModalPopped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ModalPoppedEventArgs)> ModalPopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPoppedEventArgs>, (object, global::Xamarin.Forms.ModalPoppedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ModalPoppedEventArgs> ModalPopped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPoppedEventArgs>, global::Xamarin.Forms.ModalPoppedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ModalPoppedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ModalPoppedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -264,9 +264,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.ModalPopping"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ModalPoppingEventArgs)> ModalPopping => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPoppingEventArgs>, (object, global::Xamarin.Forms.ModalPoppingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ModalPoppingEventArgs> ModalPopping => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPoppingEventArgs>, global::Xamarin.Forms.ModalPoppingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ModalPoppingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ModalPoppingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -274,9 +274,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.ModalPushed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ModalPushedEventArgs)> ModalPushed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPushedEventArgs>, (object, global::Xamarin.Forms.ModalPushedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ModalPushedEventArgs> ModalPushed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPushedEventArgs>, global::Xamarin.Forms.ModalPushedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ModalPushedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ModalPushedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -284,9 +284,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.ModalPushing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ModalPushingEventArgs)> ModalPushing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPushingEventArgs>, (object, global::Xamarin.Forms.ModalPushingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ModalPushingEventArgs> ModalPushing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ModalPushingEventArgs>, global::Xamarin.Forms.ModalPushingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ModalPushingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ModalPushingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -294,9 +294,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.PageAppearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Page)> PageAppearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Page>, (object, global::Xamarin.Forms.Page)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Page> PageAppearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Page>, global::Xamarin.Forms.Page>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Page e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Page e) => eventHandler(e);
             return Handler;
         }
 
@@ -304,9 +304,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Application.PageDisappearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Page)> PageDisappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Page>, (object, global::Xamarin.Forms.Page)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Page> PageDisappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Page>, global::Xamarin.Forms.Page>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Page e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Page e) => eventHandler(e);
             return Handler;
         }
 
@@ -331,9 +331,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.BindableObject.BindingContextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> BindingContextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> BindingContextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -341,9 +341,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.BindableObject.PropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -351,9 +351,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.BindableObject.PropertyChanging"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.PropertyChangingEventArgs)> PropertyChanging => global::System.Reactive.Linq.Observable.FromEvent<global::Xamarin.Forms.PropertyChangingEventHandler, (object, global::Xamarin.Forms.PropertyChangingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.PropertyChangingEventArgs> PropertyChanging => global::System.Reactive.Linq.Observable.FromEvent<global::Xamarin.Forms.PropertyChangingEventHandler, global::Xamarin.Forms.PropertyChangingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.PropertyChangingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.PropertyChangingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -378,9 +378,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Button.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -388,9 +388,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Button.Pressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -398,9 +398,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Button.Released"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -425,9 +425,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Cell.Appearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Appearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Appearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -435,9 +435,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Cell.Disappearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Disappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Disappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -445,9 +445,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Cell.ForceUpdateSizeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ForceUpdateSizeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ForceUpdateSizeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -455,9 +455,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Cell.Tapped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Tapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Tapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -482,9 +482,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ChildGestureRecognizer.PropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -509,9 +509,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ClickGestureRecognizer.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -536,9 +536,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ColumnDefinition.SizeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -563,9 +563,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Command.CanExecuteChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> CanExecuteChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> CanExecuteChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -590,9 +590,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.DatePicker.DateSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.DateChangedEventArgs)> DateSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.DateChangedEventArgs>, (object, global::Xamarin.Forms.DateChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.DateChangedEventArgs> DateSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.DateChangedEventArgs>, global::Xamarin.Forms.DateChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.DateChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.DateChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -617,9 +617,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Editor.Completed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -627,9 +627,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Editor.TextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.TextChangedEventArgs)> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, (object, global::Xamarin.Forms.TextChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.TextChangedEventArgs> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, global::Xamarin.Forms.TextChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -654,9 +654,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.ChildAdded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ElementEventArgs)> ChildAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, (object, global::Xamarin.Forms.ElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ElementEventArgs> ChildAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, global::Xamarin.Forms.ElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -664,9 +664,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.ChildRemoved"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ElementEventArgs)> ChildRemoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, (object, global::Xamarin.Forms.ElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ElementEventArgs> ChildRemoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, global::Xamarin.Forms.ElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -674,9 +674,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.DescendantAdded"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ElementEventArgs)> DescendantAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, (object, global::Xamarin.Forms.ElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ElementEventArgs> DescendantAdded => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, global::Xamarin.Forms.ElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -684,9 +684,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.DescendantRemoved"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ElementEventArgs)> DescendantRemoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, (object, global::Xamarin.Forms.ElementEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ElementEventArgs> DescendantRemoved => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ElementEventArgs>, global::Xamarin.Forms.ElementEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ElementEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -695,9 +695,9 @@ namespace Xamarin.Forms
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Element.PlatformSet"/> event triggers.
         /// </summary>
         [global::System.ObsoleteAttribute("PlatformSet is obsolete as of 3.5.0. Do not use this event.", false)]
-        public global::System.IObservable<(object, global::System.EventArgs)> PlatformSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> PlatformSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -722,9 +722,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Entry.Completed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -732,9 +732,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Entry.TextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.TextChangedEventArgs)> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, (object, global::Xamarin.Forms.TextChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.TextChangedEventArgs> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, global::Xamarin.Forms.TextChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -759,9 +759,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.EntryCell.Completed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Completed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -786,9 +786,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ICellController.ForceUpdateSizeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ForceUpdateSizeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ForceUpdateSizeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -813,9 +813,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IDefinition.SizeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -841,9 +841,9 @@ namespace Xamarin.Forms
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IElementController.PlatformSet"/> event triggers.
         /// </summary>
         [global::System.ObsoleteAttribute("PlatformSet is obsolete as of 3.5.0. Do not use this event.", false)]
-        public global::System.IObservable<(object, global::System.EventArgs)> PlatformSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> PlatformSet => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -868,9 +868,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ILayout.LayoutChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -895,9 +895,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IListProxy.CollectionChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs)> CollectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler, (object, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.Collections.Specialized.NotifyCollectionChangedEventArgs> CollectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.Collections.Specialized.NotifyCollectionChangedEventHandler, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.Collections.Specialized.NotifyCollectionChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -922,9 +922,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IListViewController.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestedEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestedEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, global::Xamarin.Forms.ScrollToRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -949,9 +949,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ImageButton.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -959,9 +959,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ImageButton.Pressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Pressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -969,9 +969,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ImageButton.Released"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Released => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -996,9 +996,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IMasterDetailPageController.BackButtonPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.BackButtonPressedEventArgs)> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.BackButtonPressedEventArgs>, (object, global::Xamarin.Forms.BackButtonPressedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.BackButtonPressedEventArgs> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.BackButtonPressedEventArgs>, global::Xamarin.Forms.BackButtonPressedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.BackButtonPressedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.BackButtonPressedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1023,9 +1023,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.InsertPageBeforeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> InsertPageBeforeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> InsertPageBeforeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1033,9 +1033,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.PopRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PopRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PopRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1043,9 +1043,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.PopToRootRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PopToRootRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PopToRootRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1053,9 +1053,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.PushRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PushRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PushRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1063,9 +1063,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.INavigationPageController.RemovePageRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> RemovePageRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> RemovePageRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1090,9 +1090,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IOpenGlViewController.DisplayRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DisplayRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DisplayRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1117,9 +1117,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IScrollViewController.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestedEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestedEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, global::Xamarin.Forms.ScrollToRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1144,9 +1144,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ISearchHandlerController.ListProxyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ListProxyChangedEventArgs)> ListProxyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ListProxyChangedEventArgs>, (object, global::Xamarin.Forms.ListProxyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ListProxyChangedEventArgs> ListProxyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ListProxyChangedEventArgs>, global::Xamarin.Forms.ListProxyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ListProxyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ListProxyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1171,9 +1171,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IShellController.StructureChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> StructureChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> StructureChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1198,9 +1198,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IShellSectionController.NavigationRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> NavigationRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> NavigationRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1225,9 +1225,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ITableViewController.ModelChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ModelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ModelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1252,9 +1252,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ItemsView.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestEventArgs>, global::Xamarin.Forms.ScrollToRequestEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1279,9 +1279,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IVisualElementController.BatchCommitted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>)> BatchCommitted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>, (object, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>> BatchCommitted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement> e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement> e) => eventHandler(e);
             return Handler;
         }
 
@@ -1289,9 +1289,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IVisualElementController.FocusChangeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, (object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.VisualElement.FocusRequestArgs> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, global::Xamarin.Forms.VisualElement.FocusRequestArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1316,9 +1316,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IWebViewController.EvalRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EvalRequested)> EvalRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EvalRequested>, (object, global::Xamarin.Forms.Internals.EvalRequested)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EvalRequested> EvalRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EvalRequested>, global::Xamarin.Forms.Internals.EvalRequested>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EvalRequested e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EvalRequested e) => eventHandler(e);
             return Handler;
         }
 
@@ -1326,9 +1326,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IWebViewController.GoBackRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> GoBackRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> GoBackRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1336,9 +1336,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IWebViewController.GoForwardRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> GoForwardRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> GoForwardRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1346,9 +1346,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.IWebViewController.ReloadRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ReloadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ReloadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1373,9 +1373,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Layout.LayoutChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1400,9 +1400,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ItemAppearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ItemVisibilityEventArgs)> ItemAppearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemVisibilityEventArgs>, (object, global::Xamarin.Forms.ItemVisibilityEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ItemVisibilityEventArgs> ItemAppearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemVisibilityEventArgs>, global::Xamarin.Forms.ItemVisibilityEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ItemVisibilityEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ItemVisibilityEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1410,9 +1410,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ItemDisappearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ItemVisibilityEventArgs)> ItemDisappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemVisibilityEventArgs>, (object, global::Xamarin.Forms.ItemVisibilityEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ItemVisibilityEventArgs> ItemDisappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemVisibilityEventArgs>, global::Xamarin.Forms.ItemVisibilityEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ItemVisibilityEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ItemVisibilityEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1420,9 +1420,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.SelectedItemChangedEventArgs)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SelectedItemChangedEventArgs>, (object, global::Xamarin.Forms.SelectedItemChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.SelectedItemChangedEventArgs> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SelectedItemChangedEventArgs>, global::Xamarin.Forms.SelectedItemChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.SelectedItemChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.SelectedItemChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1430,9 +1430,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ItemTapped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ItemTappedEventArgs)> ItemTapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemTappedEventArgs>, (object, global::Xamarin.Forms.ItemTappedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ItemTappedEventArgs> ItemTapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ItemTappedEventArgs>, global::Xamarin.Forms.ItemTappedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ItemTappedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ItemTappedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1440,9 +1440,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.Refreshing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Refreshing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Refreshing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1450,9 +1450,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ListView.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestedEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestedEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, global::Xamarin.Forms.ScrollToRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1477,9 +1477,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.MasterDetailPage.BackButtonPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.BackButtonPressedEventArgs)> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.BackButtonPressedEventArgs>, (object, global::Xamarin.Forms.BackButtonPressedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.BackButtonPressedEventArgs> BackButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.BackButtonPressedEventArgs>, global::Xamarin.Forms.BackButtonPressedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.BackButtonPressedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.BackButtonPressedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1487,9 +1487,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.MasterDetailPage.IsPresentedChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> IsPresentedChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> IsPresentedChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1514,9 +1514,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.MenuItem.Clicked"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Clicked => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1541,9 +1541,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.InsertPageBeforeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> InsertPageBeforeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> InsertPageBeforeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1551,9 +1551,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.Popped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.NavigationEventArgs)> Popped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, (object, global::Xamarin.Forms.NavigationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.NavigationEventArgs> Popped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, global::Xamarin.Forms.NavigationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1561,9 +1561,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.PoppedToRoot"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.NavigationEventArgs)> PoppedToRoot => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, (object, global::Xamarin.Forms.NavigationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.NavigationEventArgs> PoppedToRoot => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, global::Xamarin.Forms.NavigationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1571,9 +1571,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.PopRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PopRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PopRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1581,9 +1581,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.PopToRootRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PopToRootRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PopToRootRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1591,9 +1591,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.Pushed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.NavigationEventArgs)> Pushed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, (object, global::Xamarin.Forms.NavigationEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.NavigationEventArgs> Pushed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.NavigationEventArgs>, global::Xamarin.Forms.NavigationEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.NavigationEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1601,9 +1601,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.PushRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> PushRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> PushRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1611,9 +1611,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.NavigationPage.RemovePageRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)> RemovePageRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, (object, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs> RemovePageRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.NavigationRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1638,9 +1638,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.OpenGLView.DisplayRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DisplayRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DisplayRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1665,9 +1665,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Page.Appearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Appearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Appearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1675,9 +1675,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Page.Disappearing"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Disappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Disappearing => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1685,9 +1685,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Page.LayoutChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> LayoutChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1712,9 +1712,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.PanGestureRecognizer.PanUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.PanUpdatedEventArgs)> PanUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.PanUpdatedEventArgs>, (object, global::Xamarin.Forms.PanUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.PanUpdatedEventArgs> PanUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.PanUpdatedEventArgs>, global::Xamarin.Forms.PanUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.PanUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.PanUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1739,9 +1739,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Picker.SelectedIndexChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SelectedIndexChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SelectedIndexChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1766,9 +1766,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.PinchGestureRecognizer.PinchUpdated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.PinchGestureUpdatedEventArgs)> PinchUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.PinchGestureUpdatedEventArgs>, (object, global::Xamarin.Forms.PinchGestureUpdatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.PinchGestureUpdatedEventArgs> PinchUpdated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.PinchGestureUpdatedEventArgs>, global::Xamarin.Forms.PinchGestureUpdatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.PinchGestureUpdatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.PinchGestureUpdatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1793,9 +1793,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.RowDefinition.SizeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1820,9 +1820,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ScrollView.Scrolled"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrolledEventArgs)> Scrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrolledEventArgs>, (object, global::Xamarin.Forms.ScrolledEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrolledEventArgs> Scrolled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrolledEventArgs>, global::Xamarin.Forms.ScrolledEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrolledEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrolledEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1830,9 +1830,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ScrollView.ScrollToRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ScrollToRequestedEventArgs)> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, (object, global::Xamarin.Forms.ScrollToRequestedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ScrollToRequestedEventArgs> ScrollToRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ScrollToRequestedEventArgs>, global::Xamarin.Forms.ScrollToRequestedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ScrollToRequestedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1857,9 +1857,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchBar.SearchButtonPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SearchButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SearchButtonPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1867,9 +1867,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchBar.TextChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.TextChangedEventArgs)> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, (object, global::Xamarin.Forms.TextChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.TextChangedEventArgs> TextChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.TextChangedEventArgs>, global::Xamarin.Forms.TextChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.TextChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1894,9 +1894,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchHandler.FocusChangeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, (object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.VisualElement.FocusRequestArgs> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, global::Xamarin.Forms.VisualElement.FocusRequestArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1904,9 +1904,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchHandler.Focused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1914,9 +1914,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SearchHandler.Unfocused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.EventArgs>, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1941,9 +1941,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SelectableItemsView.SelectionChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.SelectionChangedEventArgs)> SelectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SelectionChangedEventArgs>, (object, global::Xamarin.Forms.SelectionChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.SelectionChangedEventArgs> SelectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SelectionChangedEventArgs>, global::Xamarin.Forms.SelectionChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.SelectionChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.SelectionChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1968,9 +1968,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Shell.Navigated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ShellNavigatedEventArgs)> Navigated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ShellNavigatedEventArgs>, (object, global::Xamarin.Forms.ShellNavigatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ShellNavigatedEventArgs> Navigated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ShellNavigatedEventArgs>, global::Xamarin.Forms.ShellNavigatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ShellNavigatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ShellNavigatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -1978,9 +1978,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Shell.Navigating"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ShellNavigatingEventArgs)> Navigating => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ShellNavigatingEventArgs>, (object, global::Xamarin.Forms.ShellNavigatingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ShellNavigatingEventArgs> Navigating => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ShellNavigatingEventArgs>, global::Xamarin.Forms.ShellNavigatingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ShellNavigatingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ShellNavigatingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2005,9 +2005,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Slider.DragCompleted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DragCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DragCompleted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2015,9 +2015,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Slider.DragStarted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> DragStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> DragStarted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2025,9 +2025,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Slider.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ValueChangedEventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ValueChangedEventArgs>, (object, global::Xamarin.Forms.ValueChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ValueChangedEventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ValueChangedEventArgs>, global::Xamarin.Forms.ValueChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ValueChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ValueChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2052,9 +2052,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Stepper.ValueChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ValueChangedEventArgs)> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ValueChangedEventArgs>, (object, global::Xamarin.Forms.ValueChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ValueChangedEventArgs> ValueChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ValueChangedEventArgs>, global::Xamarin.Forms.ValueChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ValueChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ValueChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2079,9 +2079,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SwipeGestureRecognizer.Swiped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.SwipedEventArgs)> Swiped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SwipedEventArgs>, (object, global::Xamarin.Forms.SwipedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.SwipedEventArgs> Swiped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.SwipedEventArgs>, global::Xamarin.Forms.SwipedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.SwipedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.SwipedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2106,9 +2106,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Switch.Toggled"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ToggledEventArgs)> Toggled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ToggledEventArgs>, (object, global::Xamarin.Forms.ToggledEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ToggledEventArgs> Toggled => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ToggledEventArgs>, global::Xamarin.Forms.ToggledEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ToggledEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ToggledEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2133,9 +2133,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.SwitchCell.OnChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.ToggledEventArgs)> OnChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ToggledEventArgs>, (object, global::Xamarin.Forms.ToggledEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.ToggledEventArgs> OnChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ToggledEventArgs>, global::Xamarin.Forms.ToggledEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ToggledEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ToggledEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2160,9 +2160,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.TableView.ModelChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ModelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ModelChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2187,9 +2187,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.TapGestureRecognizer.Tapped"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Tapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Tapped => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2215,9 +2215,9 @@ namespace Xamarin.Forms
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.ToolbarItem.Activated"/> event triggers.
         /// </summary>
         [global::System.ObsoleteAttribute("Activated is obsolete as of version 1.3.0. Please use Clicked instead.", false)]
-        public global::System.IObservable<(object, global::System.EventArgs)> Activated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Activated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2242,9 +2242,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.BatchCommitted"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>)> BatchCommitted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>, (object, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>> BatchCommitted => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement>>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement> e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<global::Xamarin.Forms.VisualElement> e) => eventHandler(e);
             return Handler;
         }
 
@@ -2252,9 +2252,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.ChildrenReordered"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ChildrenReordered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ChildrenReordered => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2262,9 +2262,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.FocusChangeRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, (object, global::Xamarin.Forms.VisualElement.FocusRequestArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.VisualElement.FocusRequestArgs> FocusChangeRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.VisualElement.FocusRequestArgs>, global::Xamarin.Forms.VisualElement.FocusRequestArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.VisualElement.FocusRequestArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2272,9 +2272,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.Focused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.FocusEventArgs)> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.FocusEventArgs>, (object, global::Xamarin.Forms.FocusEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.FocusEventArgs> Focused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.FocusEventArgs>, global::Xamarin.Forms.FocusEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.FocusEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.FocusEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2282,9 +2282,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.MeasureInvalidated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> MeasureInvalidated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> MeasureInvalidated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2292,9 +2292,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.SizeChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SizeChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2302,9 +2302,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.VisualElement.Unfocused"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.FocusEventArgs)> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.FocusEventArgs>, (object, global::Xamarin.Forms.FocusEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.FocusEventArgs> Unfocused => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.FocusEventArgs>, global::Xamarin.Forms.FocusEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.FocusEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.FocusEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2329,9 +2329,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.EvalRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EvalRequested)> EvalRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EvalRequested>, (object, global::Xamarin.Forms.Internals.EvalRequested)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EvalRequested> EvalRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EvalRequested>, global::Xamarin.Forms.Internals.EvalRequested>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EvalRequested e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EvalRequested e) => eventHandler(e);
             return Handler;
         }
 
@@ -2339,9 +2339,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.GoBackRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> GoBackRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> GoBackRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2349,9 +2349,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.GoForwardRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> GoForwardRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> GoForwardRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2359,9 +2359,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.Navigated"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.WebNavigatedEventArgs)> Navigated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.WebNavigatedEventArgs>, (object, global::Xamarin.Forms.WebNavigatedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.WebNavigatedEventArgs> Navigated => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.WebNavigatedEventArgs>, global::Xamarin.Forms.WebNavigatedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.WebNavigatedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.WebNavigatedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2369,9 +2369,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.Navigating"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.WebNavigatingEventArgs)> Navigating => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.WebNavigatingEventArgs>, (object, global::Xamarin.Forms.WebNavigatingEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.WebNavigatingEventArgs> Navigating => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.WebNavigatingEventArgs>, global::Xamarin.Forms.WebNavigatingEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.WebNavigatingEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.WebNavigatingEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2379,9 +2379,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.WebView.ReloadRequested"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ReloadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ReloadRequested => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2432,9 +2432,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.DeviceInfo.PropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> PropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.ComponentModel.PropertyChangedEventHandler, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2459,9 +2459,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.IResourceDictionary.ValuesChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs)> ValuesChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.ResourcesChangedEventArgs>, (object, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.ResourcesChangedEventArgs> ValuesChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.ResourcesChangedEventArgs>, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.ResourcesChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2486,9 +2486,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.TableModel.ItemLongPressed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EventArg<object>)> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<object>>, (object, global::Xamarin.Forms.Internals.EventArg<object>)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EventArg<object>> ItemLongPressed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<object>>, global::Xamarin.Forms.Internals.EventArg<object>>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<object> e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<object> e) => eventHandler(e);
             return Handler;
         }
 
@@ -2496,9 +2496,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.TableModel.ItemSelected"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Internals.EventArg<object>)> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<object>>, (object, global::Xamarin.Forms.Internals.EventArg<object>)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Internals.EventArg<object>> ItemSelected => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Internals.EventArg<object>>, global::Xamarin.Forms.Internals.EventArg<object>>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<object> e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Internals.EventArg<object> e) => eventHandler(e);
             return Handler;
         }
 
@@ -2523,9 +2523,9 @@ namespace Xamarin.Forms.Internals
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Internals.ToolbarTracker.CollectionChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> CollectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> CollectionChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2628,9 +2628,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FormsAppCompatActivity.ConfigurationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2655,9 +2655,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FormsApplicationActivity.ConfigurationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2682,9 +2682,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IBorderVisualElementRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2709,9 +2709,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IButtonLayoutRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2736,9 +2736,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IDeviceInfoProvider.ConfigurationChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> ConfigurationChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2763,9 +2763,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ImageButtonRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2773,9 +2773,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ImageButtonRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2800,9 +2800,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IShellItemRenderer.Destroyed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2827,9 +2827,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IShellObservableFragment.AnimationFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2854,9 +2854,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IShellSearchView.SearchConfirmed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SearchConfirmed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SearchConfirmed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2881,9 +2881,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ItemsViewRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2891,9 +2891,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ItemsViewRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2918,9 +2918,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IVisualElementRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2928,9 +2928,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.IVisualElementRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2955,9 +2955,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.MasterDetailRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -2982,9 +2982,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ScrollViewRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3009,9 +3009,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ShellContentFragment.AnimationFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3036,9 +3036,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ShellItemRendererBase.Destroyed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> Destroyed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3063,9 +3063,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ShellSearchView.SearchConfirmed"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> SearchConfirmed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> SearchConfirmed => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3090,9 +3090,9 @@ namespace Xamarin.Forms.Platform.Android
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.ShellSectionRenderer.AnimationFinished"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.EventArgs)> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, (object, global::System.EventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.EventArgs> AnimationFinished => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler, global::System.EventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.EventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.EventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3143,9 +3143,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3153,9 +3153,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3180,9 +3180,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.FrameRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3190,9 +3190,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.FrameRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3217,9 +3217,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3227,9 +3227,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.ImageRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3254,9 +3254,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer.ElementChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, (object, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs> ElementChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.Platform.Android.VisualElementChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3264,9 +3264,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer.ElementPropertyChanged"/> event triggers.
         /// </summary>
-        public global::System.IObservable<(object, global::System.ComponentModel.PropertyChangedEventArgs)> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, (object, global::System.ComponentModel.PropertyChangedEventArgs)>(eventHandler =>
+        public global::System.IObservable<global::System.ComponentModel.PropertyChangedEventArgs> ElementPropertyChanged => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::System.ComponentModel.PropertyChangedEventArgs>, global::System.ComponentModel.PropertyChangedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::System.ComponentModel.PropertyChangedEventArgs e) => eventHandler(e);
             return Handler;
         }
 
@@ -3284,9 +3284,9 @@ namespace Xamarin.Forms
         /// <summary>
         /// Gets an observable which signals when the <see cref = "Xamarin.Forms.Forms.ViewInitialized"/> event triggers.
         /// </summary>
-        public static global::System.IObservable<(object, global::Xamarin.Forms.ViewInitializedEventArgs)> FormsViewInitialized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ViewInitializedEventArgs>, (object, global::Xamarin.Forms.ViewInitializedEventArgs)>(eventHandler =>
+        public static global::System.IObservable<global::Xamarin.Forms.ViewInitializedEventArgs> FormsViewInitialized => global::System.Reactive.Linq.Observable.FromEvent<global::System.EventHandler<global::Xamarin.Forms.ViewInitializedEventArgs>, global::Xamarin.Forms.ViewInitializedEventArgs>(eventHandler =>
         {
-            void Handler(object sender, global::Xamarin.Forms.ViewInitializedEventArgs e) => eventHandler((sender, e));
+            void Handler(object sender, global::Xamarin.Forms.ViewInitializedEventArgs e) => eventHandler(e);
             return Handler;
         }
 


### PR DESCRIPTION
Clean up code to use 'using static' to avoid a lot of prefixes