### PR TITLE
fix: fix the mac directories

### DIFF
--- a/src/Pharmacist.Core/Extractors/PlatformExtractors/Android.cs
+++ b/src/Pharmacist.Core/Extractors/PlatformExtractors/Android.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Pharmacist.Core.Extractors.PlatformExtractors
@@ -25,6 +26,11 @@ namespace Pharmacist.Core.Extractors.PlatformExtractors
         /// <inheritdoc />
         public override Task Extract(string referenceAssembliesLocation)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                referenceAssembliesLocation = "/Library/Frameworks/Xamarin.Android.framework/Libraries/xbuild-frameworks";
+            }
+
             // Pin to a particular framework version https://github.com/reactiveui/ReactiveUI/issues/1517
             var latestVersion = Directory.GetFiles(
                 Path.Combine(referenceAssembliesLocation, "MonoAndroid"),

--- a/src/Pharmacist.Core/Extractors/PlatformExtractors/Mac.cs
+++ b/src/Pharmacist.Core/Extractors/PlatformExtractors/Mac.cs
@@ -5,6 +5,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Pharmacist.Core.Extractors.PlatformExtractors
@@ -20,6 +21,11 @@ namespace Pharmacist.Core.Extractors.PlatformExtractors
         /// <inheritdoc />
         public override Task Extract(string referenceAssembliesLocation)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                referenceAssembliesLocation = "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/";
+            }
+
             var assemblies =
                 Directory.GetFiles(
                     Path.Combine(referenceAssembliesLocation, "Xamarin.Mac"),

--- a/src/Pharmacist.Core/Extractors/PlatformExtractors/iOS.cs
+++ b/src/Pharmacist.Core/Extractors/PlatformExtractors/iOS.cs
@@ -6,6 +6,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Pharmacist.Core.Extractors.PlatformExtractors
@@ -23,6 +24,11 @@ namespace Pharmacist.Core.Extractors.PlatformExtractors
         /// <inheritdoc />
         public override Task Extract(string referenceAssembliesLocation)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                referenceAssembliesLocation = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/";
+            }
+
             var assemblies =
                 Directory.GetFiles(
                     Path.Combine(referenceAssembliesLocation, "Xamarin.iOS"),

--- a/src/Pharmacist.Core/Extractors/PlatformExtractors/tvOS.cs
+++ b/src/Pharmacist.Core/Extractors/PlatformExtractors/tvOS.cs
@@ -22,7 +22,7 @@ namespace Pharmacist.Core.Extractors.PlatformExtractors
         {
             if (PlatformHelper.IsRunningOnMono())
             {
-                referenceAssembliesLocation = Path.Combine(referenceAssembliesLocation, "Xamarin.iOS.framework/Versions/Current/lib/mono");
+                referenceAssembliesLocation = "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/";
             }
 
             var assemblies =

--- a/src/Pharmacist.Core/ReferenceLocators/ReferenceLocator.cs
+++ b/src/Pharmacist.Core/ReferenceLocators/ReferenceLocator.cs
@@ -37,7 +37,7 @@ namespace Pharmacist.Core.ReferenceLocators
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return Task.FromResult("/Library⁩/Frameworks⁩/Libraries/⁨mono");
+                return Task.FromResult("⁨/Library⁩/Frameworks⁩/Libraries/⁨mono⁩");
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
When compiling on OSX the directories to the reference libraries could be incorrect. Fix those to what was in the old event builder.