### PR TITLE
Fix: the tvos directory pointing in the wrong location for mac builds

### DIFF
--- a/src/Pharmacist.Core/Extractors/PlatformExtractors/tvOS.cs
+++ b/src/Pharmacist.Core/Extractors/PlatformExtractors/tvOS.cs
@@ -22,7 +22,7 @@ namespace Pharmacist.Core.Extractors.PlatformExtractors
         {
             if (PlatformHelper.IsRunningOnMono())
             {
-                referenceAssembliesLocation = "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/";
+                referenceAssembliesLocation = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/";
             }
 
             var assemblies =


### PR DESCRIPTION
The TVOS is pointing towards the wrong location.