### PR TITLE
feature: add project type guid support to support older csproj format

### DIFF
--- a/src/Pharmacist.MsBuild.NuGet/PharmacistNuGetTask.cs
+++ b/src/Pharmacist.MsBuild.NuGet/PharmacistNuGetTask.cs
@@ -27,6 +27,8 @@ namespace Pharmacist.MsBuild.NuGet
     [SuppressMessage("Design", "CA1031: Catch specific exceptions", Justification = "Final logging location for exceptions.")]
     public class PharmacistNuGetTask : Task, IEnableLogger
     {
+        private const string DefaultTargetFramework = "netstandard2.0";
+
         private static readonly ISet<string> ExclusionPackageReferenceSet = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
         {
             "Pharmacist.MSBuild",
@@ -42,8 +44,7 @@ namespace Pharmacist.MsBuild.NuGet
         /// <summary>
         /// Gets or sets the target framework.
         /// </summary>
-        [Required]
-        public string TargetFramework { get; set; }
+        public string TargetFramework { get; set; } = DefaultTargetFramework;
 
         /// <summary>
         /// Gets or sets the output file.
@@ -65,8 +66,7 @@ namespace Pharmacist.MsBuild.NuGet
 
             if (string.IsNullOrWhiteSpace(TargetFramework))
             {
-                Log.LogError($"{nameof(TargetFramework)} is not set");
-                return false;
+                TargetFramework = DefaultTargetFramework;
             }
 
             using (var writer = new StreamWriter(Path.Combine(OutputFile)))

--- a/src/Pharmacist.MsBuild.NuGet/PharmacistNuGetTask.cs
+++ b/src/Pharmacist.MsBuild.NuGet/PharmacistNuGetTask.cs
@@ -7,10 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
 
@@ -27,8 +27,6 @@ namespace Pharmacist.MsBuild.NuGet
     [SuppressMessage("Design", "CA1031: Catch specific exceptions", Justification = "Final logging location for exceptions.")]
     public class PharmacistNuGetTask : Task, IEnableLogger
     {
-        private const string DefaultTargetFramework = "netstandard2.0";
-
         private static readonly ISet<string> ExclusionPackageReferenceSet = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
         {
             "Pharmacist.MSBuild",
@@ -42,9 +40,19 @@ namespace Pharmacist.MsBuild.NuGet
         public ITaskItem[] PackageReferences { get; set; }
 
         /// <summary>
+        /// Gets or sets the guids of the project types.
+        /// </summary>
+        public string ProjectTypeGuids { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the project type.
+        /// </summary>
+        public string TargetFrameworkVersion { get; set; }
+
+        /// <summary>
         /// Gets or sets the target framework.
         /// </summary>
-        public string TargetFramework { get; set; } = DefaultTargetFramework;
+        public string TargetFramework { get; set; }
 
         /// <summary>
         /// Gets or sets the output file.
@@ -64,40 +72,22 @@ namespace Pharmacist.MsBuild.NuGet
                 return false;
             }
 
-            if (string.IsNullOrWhiteSpace(TargetFramework))
+            var nugetFrameworks = GetTargetFrameworks();
+            if (nugetFrameworks == null)
             {
-                TargetFramework = DefaultTargetFramework;
+                Log.LogError("Neither TargetFramework nor ProjectTypeGuids have been correctly set.");
+                return false;
             }
 
             using (var writer = new StreamWriter(Path.Combine(OutputFile)))
             {
-                var packages = new List<LibraryRange>();
-
-                // Include all package references that aren't ourselves.
-                foreach (var packageReference in PackageReferences)
-                {
-                    var include = packageReference.GetMetadata("PackageName");
-
-                    if (ExclusionPackageReferenceSet.Contains(include))
-                    {
-                        continue;
-                    }
-
-                    if (!VersionRange.TryParse(packageReference.GetMetadata("Version"), out var nuGetVersion))
-                    {
-                        this.Log().Error($"Package {include} does not have a valid Version.");
-                        continue;
-                    }
-
-                    var packageIdentity = new LibraryRange(include, nuGetVersion, LibraryDependencyTarget.Package);
-                    packages.Add(packageIdentity);
-                }
+                var packages = GetPackages();
 
                 ObservablesForEventGenerator.WriteHeader(writer, packages).ConfigureAwait(false).GetAwaiter().GetResult();
 
                 try
                 {
-                    ObservablesForEventGenerator.ExtractEventsFromNuGetPackages(writer, packages, TargetFramework.ToFrameworks()).GetAwaiter().GetResult();
+                    ObservablesForEventGenerator.ExtractEventsFromNuGetPackages(writer, packages, nugetFrameworks).GetAwaiter().GetResult();
                 }
                 catch (Exception ex)
                 {
@@ -107,6 +97,57 @@ namespace Pharmacist.MsBuild.NuGet
             }
 
             return true;
+        }
+
+        private IReadOnlyCollection<NuGetFramework> GetTargetFrameworks()
+        {
+            IReadOnlyCollection<NuGetFramework> nugetFrameworks;
+            if (!string.IsNullOrWhiteSpace(TargetFramework))
+            {
+                nugetFrameworks = TargetFramework.ToFrameworks();
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(ProjectTypeGuids) || string.IsNullOrWhiteSpace(TargetFrameworkVersion))
+                {
+                    return null;
+                }
+
+                var splitProjectTypeGuids = ProjectTypeGuids
+                    .Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(x => new Guid(x.Trim()));
+
+                nugetFrameworks = new List<NuGetFramework> { splitProjectTypeGuids.GetTargetFramework(TargetFrameworkVersion) };
+            }
+
+            return nugetFrameworks;
+        }
+
+        private List<LibraryRange> GetPackages()
+        {
+            var packages = new List<LibraryRange>();
+
+            // Include all package references that aren't ourselves.
+            foreach (var packageReference in PackageReferences)
+            {
+                var include = packageReference.GetMetadata("PackageName");
+
+                if (ExclusionPackageReferenceSet.Contains(include))
+                {
+                    continue;
+                }
+
+                if (!VersionRange.TryParse(packageReference.GetMetadata("Version"), out var nuGetVersion))
+                {
+                    this.Log().Error($"Package {include} does not have a valid Version.");
+                    continue;
+                }
+
+                var packageIdentity = new LibraryRange(include, nuGetVersion, LibraryDependencyTarget.Package);
+                packages.Add(packageIdentity);
+            }
+
+            return packages;
         }
     }
 }

--- a/src/Pharmacist.MsBuild.NuGet/ProjectGuidToTargetFramework.cs
+++ b/src/Pharmacist.MsBuild.NuGet/ProjectGuidToTargetFramework.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace Pharmacist.MsBuild.NuGet
+{
+    /// <summary>
+    /// Converts the project guid format into a target framework value.
+    /// </summary>
+    internal static class ProjectGuidToTargetFramework
+    {
+        private static readonly Dictionary<Guid, string> _guidToFramework = new Dictionary<Guid, string>()
+        {
+            [new Guid("EFBA0AD7-5A72-4C68-AF49-83D382785DCF")] = "MonoAndroid",
+            [new Guid("6BC8ED88-2882-458C-8E55-DFD12B67127B")] = "Xamarin.iOS",
+            [new Guid("A5A43C5B-DE2A-4C0C-9213-0A381AF9435A")] = "uap",
+            [new Guid("A3F8F2AB-B479-4A4A-A458-A89E7DC349F1")] = "Xamarin.Mac",
+        };
+
+        public static NuGetFramework GetTargetFramework(this IEnumerable<Guid> projectGuids, string projectVersionId)
+        {
+            foreach (var projectGuid in projectGuids)
+            {
+                if (_guidToFramework.TryGetValue(projectGuid, out var targetFrameworkValue))
+                {
+                    return new NuGetFramework(targetFrameworkValue, new Version(projectVersionId));
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Pharmacist.MsBuild.NuGet/targets/Pharmacist.MSBuild.targets
+++ b/src/Pharmacist.MsBuild.NuGet/targets/Pharmacist.MSBuild.targets
@@ -45,6 +45,8 @@
   <Target Name="GeneratePharmacist" BeforeTargets="CoreCompile">
     <PharmacistNuGetTask PackageReferences="@(PharmacistPackageReference -> WithMetadataValue('InProject', True) )"
                          TargetFramework="$(TargetFramework)"
+                         TargetFrameworkVersion="$(TargetFrameworkVersion)"
+                         ProjectTypeGuids="$(ProjectTypeGuids)"
                          OutputFile="$(IntermediateOutputPath)\Pharmacist.NuGet.g.cs" />
 
     <Message Text="Processed Pharmacist Packages" />

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3",
+  "version": "1.4",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/develop$", // we release out of develop


### PR DESCRIPTION
If TargetFramework property does not exist, use the ProjectTypeGuids and TargetFrameworkVersion properties to determine the TargetFramework.

Should solve some projects that use the old Project Format and use deprecated shared projects.