### PR TITLE
Fix: add a lock file to prevent excessive generation

### DIFF
--- a/src/Pharmacist.MsBuild.NuGet/Pharmacist.MsBuild.NuGet.csproj
+++ b/src/Pharmacist.MsBuild.NuGet/Pharmacist.MsBuild.NuGet.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Condition="'$(TargetFramework)' == 'net461' " Include="Microsoft.Build.Tasks.Core" Version="14.3" PrivateAssets="all" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0' " Include="Microsoft.Build.Tasks.Core" Version="15.1.548" PrivateAssets="all" />
+    
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup Label="Package">

--- a/src/Pharmacist.MsBuild.NuGet/targets/Pharmacist.MSBuild.targets
+++ b/src/Pharmacist.MsBuild.NuGet/targets/Pharmacist.MSBuild.targets
@@ -38,6 +38,8 @@
     <IntermediateOutputPath Condition="$(IntermediateOutputPath) == '' Or $(IntermediateOutputPath) == '*Undefined*'">$(MSBuildProjectDirectory)\obj\$(Configuration)\</IntermediateOutputPath>
     <PharmacistTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Full'">$(MSBuildThisFileDirectory)..\..\build\netstandard2.0\Pharmacist.MSBuild.dll</PharmacistTaskAssemblyFile>
     <PharmacistTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Full'">$(MSBuildThisFileDirectory)..\..\build\net461\Pharmacist.MSBuild.dll</PharmacistTaskAssemblyFile>
+    <PharmacistOutputFile>$(IntermediateOutputPath)\Pharmacist.NuGet.g.cs</PharmacistOutputFile>
+    <PharmacistLockFile>$(IntermediateOutputPath)\Pharmacist.NuGet.g.cs</PharmacistLockFile>
   </PropertyGroup>
 
   <UsingTask TaskName="Pharmacist.MsBuild.NuGet.PharmacistNuGetTask" AssemblyFile="$(PharmacistTaskAssemblyFile)" />
@@ -48,12 +50,13 @@
                          TargetFrameworkVersion="$(TargetFrameworkVersion)"
                          ProjectTypeGuids="$(ProjectTypeGuids)"
                          TargetPlatformVersion="$(TargetPlatformVersion)"
-                         OutputFile="$(IntermediateOutputPath)\Pharmacist.NuGet.g.cs" />
+                         OutputFile="$(PharmacistOutputFile)"
+                         LockFile="$(PharmacistLockFile)"/>
 
     <Message Text="Processed Pharmacist Packages" />
 
-    <ItemGroup Condition="Exists('$(IntermediateOutputPath)\Pharmacist.NuGet.g.cs')">
-      <Compile Include="$(IntermediateOutputPath)\Pharmacist.NuGet.g.cs" />
+    <ItemGroup Condition="Exists('$(PharmacistOutputFile)')">
+      <Compile Include="$(PharmacistOutputFile)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Pharmacist.Tests/AssemblyIntegrationTests.cs
+++ b/src/Pharmacist.Tests/AssemblyIntegrationTests.cs
@@ -19,6 +19,9 @@ using Xunit;
 
 namespace Pharmacist.Tests
 {
+    /// <summary>
+    /// Tests for testing different assemblies.
+    /// </summary>
     public class AssemblyIntegrationTests
     {
         /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix
**What is the current behavior?**
<!-- You can also link to an open issue here. -->
That it generates every compile


**What is the new behavior?**
<!-- If this is a feature change -->

It checks to see if there is an existing compilation with the same nuget packages, if there is it won't bother generating.

**What might this PR break?**
Maybe generation.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

