### PR TITLE
Fix: requirement on json.net and also ffimage generation

### DIFF
--- a/src/Pharmacist.Core/Generation/Generators/InstanceEventGenerator.cs
+++ b/src/Pharmacist.Core/Generation/Generators/InstanceEventGenerator.cs
@@ -50,7 +50,7 @@ namespace Pharmacist.Core.Generation.Generators
                 .WithLeadingTrivia(XmlSyntaxFactory.GenerateSummarySeeAlsoComment("A class that contains extension methods to wrap events for classes contained within the {0} namespace.", namespaceName))
                 .WithMembers(List<MemberDeclarationSyntax>(declarations.Select(declaration =>
                     {
-                        var eventsClassName = IdentifierName(declaration.Name + "Events");
+                        var eventsClassName = IdentifierName("Rx" + declaration.Name + "Events");
                         return MethodDeclaration(eventsClassName, Identifier("Events"))
                             .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
                             .WithParameterList(ParameterList(SingletonSeparatedList(
@@ -70,7 +70,7 @@ namespace Pharmacist.Core.Generation.Generators
         {
             const string dataParameterName = "data";
             var constructor = ConstructorDeclaration(
-                    Identifier(typeDefinition.Name + "Events"))
+                    Identifier("Rx" + typeDefinition.Name + "Events"))
                 .WithModifiers(
                     TokenList(
                         Token(SyntaxKind.PublicKeyword)))

--- a/src/Pharmacist.Core/NuGet/NuGetPackageHelper.cs
+++ b/src/Pharmacist.Core/NuGet/NuGetPackageHelper.cs
@@ -129,6 +129,28 @@ namespace Pharmacist.Core.NuGet
         /// Gets the best matching PackageIdentity for the specified LibraryRange.
         /// </summary>
         /// <param name="identity">The library range to find the best patch for.</param>
+        /// <param name="nugetSource">Optional v3 nuget source. Will default to default nuget.org servers.</param>
+        /// <param name="token">A optional cancellation token.</param>
+        /// <returns>The best matching PackageIdentity to the specified version range.</returns>
+        public static async Task<PackageIdentity> GetBestMatch(LibraryRange identity, PackageSource? nugetSource = null, CancellationToken token = default)
+        {
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+
+            // Use the provided nuget package source, or use nuget.org
+            var sourceRepository = new SourceRepository(nugetSource ?? new PackageSource(DefaultNuGetSource), Providers);
+
+            var findPackageResource = await sourceRepository.GetResourceAsync<FindPackageByIdResource>(token).ConfigureAwait(false);
+
+            return await GetBestMatch(identity, findPackageResource, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the best matching PackageIdentity for the specified LibraryRange.
+        /// </summary>
+        /// <param name="identity">The library range to find the best patch for.</param>
         /// <param name="findPackageResource">The source repository where to match.</param>
         /// <param name="token">A optional cancellation token.</param>
         /// <returns>The best matching PackageIdentity to the specified version range.</returns>

--- a/src/Pharmacist.Core/ObservablesForEventGenerator.cs
+++ b/src/Pharmacist.Core/ObservablesForEventGenerator.cs
@@ -232,6 +232,34 @@ namespace Pharmacist.Core
         /// Writes the header for a output.
         /// </summary>
         /// <param name="writer">The writer where to output to.</param>
+        /// <param name="packageIdentities">The packages included in the output.</param>
+        /// <returns>A task to monitor the progress.</returns>
+        public static async Task WriteHeader(TextWriter writer, IReadOnlyCollection<PackageIdentity> packageIdentities)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            if (packageIdentities == null)
+            {
+                throw new ArgumentNullException(nameof(packageIdentities));
+            }
+
+            await WriteHeader(writer).ConfigureAwait(false);
+
+            foreach (var packageIdentity in packageIdentities)
+            {
+                await writer.WriteLineAsync($"// Package included: {packageIdentity}").ConfigureAwait(false);
+            }
+
+            await writer.FlushAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Writes the header for a output.
+        /// </summary>
+        /// <param name="writer">The writer where to output to.</param>
         /// <param name="fileNames">The file name to write.</param>
         /// <returns>A task to monitor the progress.</returns>
         public static async Task WriteHeader(TextWriter writer, IEnumerable<string> fileNames)

--- a/src/Pharmacist.Core/Pharmacist.Core.csproj
+++ b/src/Pharmacist.Core/Pharmacist.Core.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="NuGet.LibraryModel" Version="5.2.0" />
     <PackageReference Include="polly" Version="7.2.0" />
     <PackageReference Include="splat" Version="9.3.11" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">

--- a/src/Pharmacist.MsBuild.NuGet/Pharmacist.MsBuild.NuGet.csproj
+++ b/src/Pharmacist.MsBuild.NuGet/Pharmacist.MsBuild.NuGet.csproj
@@ -11,6 +11,7 @@
     <PackageDescription>Produces from NuGet packages System.Reactive Observables for all events within the NuGet packages inside the project..</PackageDescription>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
     <NoWarn>$(NoWarn);CA1819</NoWarn>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,6 +35,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Pharmacist.Core\Pharmacist.Core.csproj" PrivateAssets="All" />
     <ProjectReference Include="..\Pharmacist.Common\Pharmacist.Common.csproj" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Pharmacist.MsBuild.NuGet/PharmacistNuGetTask.cs
+++ b/src/Pharmacist.MsBuild.NuGet/PharmacistNuGetTask.cs
@@ -8,11 +8,13 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 using Pharmacist.Core;
@@ -29,6 +31,7 @@ namespace Pharmacist.MsBuild.NuGet
     public class PharmacistNuGetTask : Task, IEnableLogger
     {
         private static readonly Regex _versionRegex = new Regex(@"(\d+\.)?(\d+\.)?(\d+\.)?(\*|\d+)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex _packageRegex = new Regex("^(.*)/(.*)$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         private static readonly Dictionary<Guid, string> _guidToFramework = new Dictionary<Guid, string>()
         {
             [new Guid("EFBA0AD7-5A72-4C68-AF49-83D382785DCF")] = "MonoAndroid",
@@ -78,6 +81,7 @@ namespace Pharmacist.MsBuild.NuGet
         /// <inheritdoc />
         public override bool Execute()
         {
+            var lockFile = OutputFile + ".lock";
             var funcLogManager = new FuncLogManager(type => new WrappingFullLogger(new WrappingPrefixLogger(new MsBuildLogger(Log, LogLevel.Debug), type)));
             Locator.CurrentMutable.RegisterConstant(funcLogManager, typeof(ILogManager));
 
@@ -94,10 +98,17 @@ namespace Pharmacist.MsBuild.NuGet
                 return false;
             }
 
-            using (var writer = new StreamWriter(Path.Combine(OutputFile)))
-            {
-                var packages = GetPackages();
+            var packages = GetPackages();
 
+            var lockPackages = ReadPackages(lockFile);
+
+            if (lockPackages != null && lockPackages.Count == packages.Count && lockPackages.All(packages.Contains))
+            {
+                return true;
+            }
+
+            using (var writer = new StreamWriter(Path.Combine(OutputFile), false, Encoding.UTF8))
+            {
                 ObservablesForEventGenerator.WriteHeader(writer, packages).ConfigureAwait(false).GetAwaiter().GetResult();
 
                 try
@@ -110,6 +121,8 @@ namespace Pharmacist.MsBuild.NuGet
                     return false;
                 }
             }
+
+            WritePackages(packages, lockFile);
 
             return true;
         }
@@ -145,9 +158,9 @@ namespace Pharmacist.MsBuild.NuGet
             return nugetFrameworks;
         }
 
-        private List<LibraryRange> GetPackages()
+        private List<PackageIdentity> GetPackages()
         {
-            var packages = new List<LibraryRange>();
+            var packages = new List<PackageIdentity>();
 
             // Include all package references that aren't ourselves.
             foreach (var packageReference in PackageReferences)
@@ -165,11 +178,63 @@ namespace Pharmacist.MsBuild.NuGet
                     continue;
                 }
 
-                var packageIdentity = new LibraryRange(include, nuGetVersion, LibraryDependencyTarget.Package);
+                var libraryRange = new LibraryRange(include, nuGetVersion, LibraryDependencyTarget.Package);
+                var packageIdentity = NuGetPackageHelper.GetBestMatch(libraryRange).GetAwaiter().GetResult();
                 packages.Add(packageIdentity);
             }
 
             return packages;
+        }
+
+        private void WritePackages(List<PackageIdentity> packageIdentities, string lockFileName)
+        {
+            using var streamWriter = new StreamWriter(lockFileName, false, Encoding.UTF8);
+            foreach (var packageIdentity in packageIdentities)
+            {
+                streamWriter.WriteLine($"{packageIdentity.Id}/{packageIdentity.Version}");
+            }
+        }
+
+        private List<PackageIdentity> ReadPackages(string lockFileName)
+        {
+            if (string.IsNullOrWhiteSpace(lockFileName))
+            {
+                throw new ArgumentException("Cannot have a empty lock file name", nameof(lockFileName));
+            }
+
+            var packageIdentities = new List<PackageIdentity>();
+
+            if (File.Exists(lockFileName) == false)
+            {
+                return packageIdentities;
+            }
+
+            try
+            {
+                using var streamReader = new StreamReader(lockFileName, Encoding.UTF8, true);
+
+                string line;
+
+                while ((line = streamReader.ReadLine()) != null)
+                {
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    var match = _packageRegex.Match(line);
+
+                    var packageIdentity = new PackageIdentity(match.Groups[1].Value, NuGetVersion.Parse(match.Groups[2].Value));
+
+                    packageIdentities.Add(packageIdentity);
+                }
+            }
+            catch
+            {
+                packageIdentities = new List<PackageIdentity>();
+            }
+
+            return packageIdentities;
         }
     }
 }

--- a/src/Pharmacist.MsBuild.TargetFramework/Pharmacist.MsBuild.TargetFramework.csproj
+++ b/src/Pharmacist.MsBuild.TargetFramework/Pharmacist.MsBuild.TargetFramework.csproj
@@ -33,6 +33,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Pharmacist.Core\Pharmacist.Core.csproj" PrivateAssets="All" />
     <ProjectReference Include="..\Pharmacist.Common\Pharmacist.Common.csproj" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Removed dependency on json.net and now use a plain text file for generating.
Add prefix of "Rx" to generated class to help avoid name collisions (eg FFImage had a name collision)