### PR TITLE
housekeeping: Mark Benchmarks and IntegrationTest as non-packable

### DIFF
--- a/src/Pharmacist.Benchmarks/Pharmacist.Benchmarks.csproj
+++ b/src/Pharmacist.Benchmarks/Pharmacist.Benchmarks.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
     <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Pharmacist.IntegrationTest/Pharmacist.IntegrationTest.csproj
+++ b/src/Pharmacist.IntegrationTest/Pharmacist.IntegrationTest.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

This PR marks `Pharmacist.Benchmarks` and `Pharmacist.IntegrationTest` packages as non-packable to avoid pushing them to NuGet.
